### PR TITLE
Support building snap packages for Linux distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ vendor/*/
 tmp/
 cover/
 yq
+
+# snapcraft
+parts/
+prime/
+.snapcraft/
+yq*.snap

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo '    make build           Build yq binary.'
 	@echo '    make install         Install yq.'
 	@echo '    make xcompile        Build cross-compiled binaries of yq.'
+	@echo '    make snap            Build a snap package of yq.'
 	@echo '    make vendor          Install dependencies using govendor.'
 	@echo '    make format          Run code formatter.'
 	@echo '    make check           Run static code analysis (lint).'
@@ -63,6 +64,10 @@ xcompile: check
 	${DOCKRUN} bash ./scripts/xcompile.sh
 	@find build -type d -exec chmod 755 {} \; || :
 	@find build -type f -exec chmod 755 {} \; || :
+
+.PHONY: snap
+snap:
+	snapcraft
 
 .PHONY: install
 install: build

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ a lightweight and portable command-line YAML processor
 The aim of the project is to be the [jq](https://github.com/stedolan/jq) or sed of yaml files.
 
 ## Install
+On MacOS:
 ```
 brew install yq
+```
+On Ubuntu and other Linux distros supporting `snap` packages:
+```
+snap install yq
 ```
 or, [Download latest binary](https://github.com/mikefarah/yq/releases/latest) or alternatively:
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,76 +5,76 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
   <head>
-    
+
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width,initial-scale=1">
       <meta http-equiv="x-ua-compatible" content="ie=edge">
-      
-      
-      
-      
+
+
+
+
         <meta name="lang:clipboard.copy" content="Copy to clipboard">
-      
+
         <meta name="lang:clipboard.copied" content="Copied to clipboard">
-      
+
         <meta name="lang:search.language" content="en">
-      
+
         <meta name="lang:search.result.none" content="No matching documents">
-      
+
         <meta name="lang:search.result.one" content="1 matching document">
-      
+
         <meta name="lang:search.result.other" content="# matching documents">
-      
+
         <meta name="lang:search.tokenizer" content="[\s\-]+">
-      
+
       <link rel="shortcut icon" href="./assets/images/favicon.png">
       <meta name="generator" content="mkdocs-0.17.2, mkdocs-material-2.2.5">
-    
-    
-      
+
+
+
         <title>Yq</title>
-      
-    
-    
+
+
+
       <link rel="stylesheet" href="./assets/stylesheets/application.bcabdff3.css">
-      
-    
-    
+
+
+
       <script src="./assets/javascripts/modernizr.1aa3b519.js"></script>
-    
-    
-      
+
+
+
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700|Roboto+Mono">
         <style>body,input{font-family:"Roboto","Helvetica Neue",Helvetica,Arial,sans-serif}code,kbd,pre{font-family:"Roboto Mono","Courier New",Courier,monospace}</style>
-      
+
       <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    
-    
-    
+
+
+
   </head>
-  
+
     <body>
-  
+
     <svg class="md-svg">
       <defs>
-        
-        
+
+
           <svg xmlns="http://www.w3.org/2000/svg" width="416" height="448" viewBox="0 0 416 448" id="github"><path fill="currentColor" d="M160 304q0 10-3.125 20.5t-10.75 19T128 352t-18.125-8.5-10.75-19T96 304t3.125-20.5 10.75-19T128 256t18.125 8.5 10.75 19T160 304zm160 0q0 10-3.125 20.5t-10.75 19T288 352t-18.125-8.5-10.75-19T256 304t3.125-20.5 10.75-19T288 256t18.125 8.5 10.75 19T320 304zm40 0q0-30-17.25-51T296 232q-10.25 0-48.75 5.25Q229.5 240 208 240t-39.25-2.75Q130.75 232 120 232q-29.5 0-46.75 21T56 304q0 22 8 38.375t20.25 25.75 30.5 15 35 7.375 37.25 1.75h42q20.5 0 37.25-1.75t35-7.375 30.5-15 20.25-25.75T360 304zm56-44q0 51.75-15.25 82.75-9.5 19.25-26.375 33.25t-35.25 21.5-42.5 11.875-42.875 5.5T212 416q-19.5 0-35.5-.75t-36.875-3.125-38.125-7.5-34.25-12.875T37 371.5t-21.5-28.75Q0 312 0 260q0-59.25 34-99-6.75-20.5-6.75-42.5 0-29 12.75-54.5 27 0 47.5 9.875t47.25 30.875Q171.5 96 212 96q37 0 70 8 26.25-20.5 46.75-30.25T376 64q12.75 25.5 12.75 54.5 0 21.75-6.75 42 34 40 34 99.5z"/></svg>
-        
+
       </defs>
     </svg>
     <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="drawer">
     <input class="md-toggle" data-md-toggle="search" type="checkbox" id="search">
     <label class="md-overlay" data-md-component="overlay" for="drawer"></label>
-    
+
       <header class="md-header" data-md-component="header">
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
         <a href="." title="Yq" class="md-header-nav__button md-logo">
-          
+
             <i class="md-icon"></i>
-          
+
         </a>
       </div>
       <div class="md-flex__cell md-flex__cell--shrink">
@@ -82,23 +82,23 @@
       </div>
       <div class="md-flex__cell md-flex__cell--stretch">
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
-          
-            
+
+
               <span class="md-header-nav__topic">
                 Yq
               </span>
               <span class="md-header-nav__topic">
                 Install
               </span>
-            
-          
+
+
         </div>
       </div>
       <div class="md-flex__cell md-flex__cell--shrink">
-        
-          
+
+
             <label class="md-icon md-icon--search md-header-nav__button" for="search"></label>
-            
+
 <div class="md-search" data-md-component="search" role="dialog">
   <label class="md-search__overlay" for="search"></label>
   <div class="md-search__inner">
@@ -119,26 +119,26 @@
     </div>
   </div>
 </div>
-          
-        
+
+
       </div>
-      
+
         <div class="md-flex__cell md-flex__cell--shrink">
           <div class="md-header-nav__source">
-            
 
 
-  
+
+
 
 
   <a href="https://github.com/mikefarah/yq/" title="Go to repository" class="md-source" data-md-source="github">
-    
+
       <div class="md-source__icon">
         <svg viewBox="0 0 24 24" width="24" height="24">
           <use xlink:href="#github" width="24" height="24"></use>
         </svg>
       </div>
-    
+
     <div class="md-source__repository">
       mikefarah/yq
     </div>
@@ -146,122 +146,129 @@
 
           </div>
         </div>
-      
+
     </div>
   </nav>
 </header>
-    
+
     <div class="md-container">
-      
-        
-      
-      
+
+
+
+
       <main class="md-main">
         <div class="md-main__inner md-grid" data-md-component="container">
-          
-            
+
+
               <div class="md-sidebar md-sidebar--primary" data-md-component="navigation">
                 <div class="md-sidebar__scrollwrap">
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="drawer">
     <span class="md-nav__button md-logo">
-      
+
         <i class="md-icon"></i>
-      
+
     </span>
     Yq
   </label>
-  
+
     <div class="md-nav__source">
-      
 
 
-  
+
+
 
 
   <a href="https://github.com/mikefarah/yq/" title="Go to repository" class="md-source" data-md-source="github">
-    
+
       <div class="md-source__icon">
         <svg viewBox="0 0 24 24" width="24" height="24">
           <use xlink:href="#github" width="24" height="24"></use>
         </svg>
       </div>
-    
+
     <div class="md-source__repository">
       mikefarah/yq
     </div>
   </a>
 
     </div>
-  
-  <ul class="md-nav__list" data-md-scrollfix>
-    
-      
-      
-      
 
-  
+  <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
 
 
   <li class="md-nav__item md-nav__item--active">
-    
+
     <input class="md-toggle md-nav__toggle" data-md-toggle="toc" type="checkbox" id="toc">
-    
-      
-    
-    
+
+
+
+
       <label class="md-nav__link md-nav__link--active" for="toc">
         Install
       </label>
-    
+
     <a href="." title="Install" class="md-nav__link md-nav__link--active">
       Install
     </a>
-    
-      
+
+
 <nav class="md-nav md-nav--secondary">
-  
-  
-    
-  
-  
+
+
+
+
+
     <label class="md-nav__title" for="toc">Table of contents</label>
     <ul class="md-nav__list" data-md-scrollfix>
-      
+
         <li class="md-nav__item">
   <a href="#brew-install-yq" title="brew install yq" class="md-nav__link">
     brew install yq
   </a>
-  
+
 </li>
-      
+
+  <li class="md-nav__item">
+<a href="#snap-install-yq" title="snap install yq" class="md-nav__link">
+snap install yq
+</a>
+
+</li>
+
         <li class="md-nav__item">
   <a href="#download-latest-binary" title="download latest binary" class="md-nav__link">
     download latest binary
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#get-the-source" title="get the source" class="md-nav__link">
     get the source
   </a>
-  
+
 </li>
-      
-      
-      
+
+
+
     </ul>
-  
+
 </nav>
-    
+
   </li>
 
-    
-      
-      
-      
+
+
+
+
 
 
   <li class="md-nav__item">
@@ -270,10 +277,10 @@
     </a>
   </li>
 
-    
-      
-      
-      
+
+
+
+
 
 
   <li class="md-nav__item">
@@ -282,10 +289,10 @@
     </a>
   </li>
 
-    
-      
-      
-      
+
+
+
+
 
 
   <li class="md-nav__item">
@@ -294,10 +301,10 @@
     </a>
   </li>
 
-    
-      
-      
-      
+
+
+
+
 
 
   <li class="md-nav__item">
@@ -306,10 +313,10 @@
     </a>
   </li>
 
-    
-      
-      
-      
+
+
+
+
 
 
   <li class="md-nav__item">
@@ -318,69 +325,77 @@
     </a>
   </li>
 
-    
+
   </ul>
 </nav>
                   </div>
                 </div>
               </div>
-            
-            
+
+
               <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
                 <div class="md-sidebar__scrollwrap">
                   <div class="md-sidebar__inner">
-                    
+
 <nav class="md-nav md-nav--secondary">
-  
-  
-    
-  
-  
+
+
+
+
+
     <label class="md-nav__title" for="toc">Table of contents</label>
     <ul class="md-nav__list" data-md-scrollfix>
-      
+
         <li class="md-nav__item">
   <a href="#brew-install-yq" title="brew install yq" class="md-nav__link">
     brew install yq
   </a>
-  
+
 </li>
-      
+
+<li class="md-nav__item">
+<a href="#snap-install-yq" title="snap install yq" class="md-nav__link">
+snap install yq
+</a>
+
+</li>
+
         <li class="md-nav__item">
   <a href="#download-latest-binary" title="download latest binary" class="md-nav__link">
     download latest binary
   </a>
-  
+
 </li>
-      
+
         <li class="md-nav__item">
   <a href="#get-the-source" title="get the source" class="md-nav__link">
     get the source
   </a>
-  
+
 </li>
-      
-      
-      
+
+
+
     </ul>
-  
+
 </nav>
                   </div>
                 </div>
               </div>
-            
-          
+
+
           <div class="md-content">
             <article class="md-content__inner md-typeset">
-              
-                
+
+
                   <a href="https://github.com/mikefarah/yq/edit/master/docs/index.md" title="Edit this page" class="md-icon md-content__icon">&#xE3C9;</a>
-                
-                
+
+
                 <h1 id="yq">yq<a class="headerlink" href="#yq" title="Permanent link">&para;</a></h1>
 <p>yq is a lightweight and portable command-line YAML processor</p>
 <p>The aim of the project is to be the <a href="https://github.com/stedolan/jq">jq</a> or sed of yaml files.</p>
 <h3 id="brew-install-yq">brew install yq<a class="headerlink" href="#brew-install-yq" title="Permanent link">&para;</a></h3>
+<h3 id="snap-install-yq">snap install yq<a class="headerlink" href="#snap-install-yq" title="Permanent link">&para;</a></h3>
 <h3 id="download-latest-binary"><a href="https://github.com/mikefarah/yq/releases/latest">download latest binary</a><a class="headerlink" href="#download-latest-binary" title="Permanent link">&para;</a></h3>
 <h3 id="get-the-source">get the source<a class="headerlink" href="#get-the-source" title="Permanent link">&para;</a></h3>
 <pre><code class="bash">go get github.com/mikefarah/yq
@@ -388,25 +403,25 @@
 
 <p><a href="https://github.com/mikefarah/yq/zipball/master">.zip</a> or <a href="https://github.com/mikefarah/yq/tarball/master">tar.gz</a></p>
 <p><a href="https://github.com/mikefarah/yq">View on GitHub</a></p>
-                
-                  
-                
-              
-              
-                
-              
+
+
+
+
+
+
+
             </article>
           </div>
         </div>
       </main>
-      
-        
+
+
 <footer class="md-footer">
-  
+
     <div class="md-footer-nav">
       <nav class="md-footer-nav__inner md-grid">
-        
-        
+
+
           <a href="read/" title="Read" class="md-flex md-footer-nav__link md-footer-nav__link--next" rel="next">
             <div class="md-flex__cell md-flex__cell--stretch md-footer-nav__title">
               <span class="md-flex__ellipsis">
@@ -420,46 +435,46 @@
               <i class="md-icon md-icon--arrow-forward md-footer-nav__button"></i>
             </div>
           </a>
-        
+
       </nav>
     </div>
-  
+
   <div class="md-footer-meta md-typeset">
     <div class="md-footer-meta__inner md-grid">
       <div class="md-footer-copyright">
-        
+
         powered by
         <a href="http://www.mkdocs.org">MkDocs</a>
         and
         <a href="https://squidfunk.github.io/mkdocs-material/">
           Material for MkDocs</a>
       </div>
-      
-        
+
+
   <div class="md-footer-social">
-    
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    
+
       <a href="https://github.com/mikefarah" class="md-footer-social__link fa fa-github"></a>
-    
+
       <a href="https://www.linkedin.com/in/mike-farah-b5a75b2/" class="md-footer-social__link fa fa-linkedin"></a>
-    
+
   </div>
 
-      
+
     </div>
   </div>
 </footer>
-      
+
     </div>
-    
+
       <script src="./assets/javascripts/application.6cdc17f0.js"></script>
-      
+
       <script>app.initialize({version:"0.17.2",url:{base:"."}})</script>
-      
-    
-    
-      
-    
+
+
+
+
+
   </body>
 </html>

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -4,8 +4,13 @@ yq is a lightweight and portable command-line YAML processor
 The aim of the project is to be the [jq](https://github.com/stedolan/jq) or sed of yaml files.
 
 ## Install
+On MacOS:
 ```
 brew install yq
+```
+On Ubuntu and other Linux distros supporting `snap` packages:
+```
+snap install yq
 ```
 or, [Download latest binary](https://github.com/mikefarah/yq/releases/latest) or alternatively:
 ```
@@ -13,4 +18,3 @@ go get github.com/mikefarah/yq
 ```
 
 [View on GitHub](https://github.com/mikefarah/yq)
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: yq
+version: git
+summary: A lightweight and portable command-line YAML processor
+description: |
+  The aim of the project is to be the jq or sed of yaml files.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  yq:
+    command: yq
+    plugs: [home]
+
+parts:
+  yq:
+    plugin: go
+    source: .
+    go-importpath: github.com/mikefarah/yq
+    #go-packages: [github.com/mikefarah/yq]
+    after: [go]
+  go:
+    source-tag: go1.9.4
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,10 @@
 name: yq
-version: git
+version: 1.14.0-dev
 summary: A lightweight and portable command-line YAML processor
 description: |
   The aim of the project is to be the jq or sed of yaml files.
 
-grade: devel # must be 'stable' to release into candidate/stable channels
+grade: stable # devel|stable. must be 'stable' to release into candidate/stable channels
 confinement: strict
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,8 +17,6 @@ parts:
     plugin: go
     source: .
     go-importpath: github.com/mikefarah/yq
-    #go-packages: [github.com/mikefarah/yq]
     after: [go]
   go:
     source-tag: go1.9.4
-


### PR DESCRIPTION
Snaps are a new packaging format for Linux distributions. They originated on Ubuntu, but support multiple Linux distributions. It would be wonderful if snap packages could be published with new releases of `yq`, like with brew packages. There is a link to the snap publishing page at the end of the PR.

This PR adds a `snap/snapcraft.yaml` file, allowing a snap package to be build by running:

```
make snap
```
This make target requires that `snapcraft` is installed. On Ubuntu, it can be installed by `snap install snapcraft --classic`, and on MacOS it can be installed by `brew install snapcraft`. Please note I've only tested this on Ubuntu.

If the snap package is published to the Ubuntu Snap Store, then users can install with:

```
snap install yq
```

The `yq` snap package uses `strict` confinement, meaning the `yq` snap has restricted access to the host system. A `home` plug has been added, allowing the `yq` snap package to access files in the users home directory. The `yq` command, when installed as a snap, will not be able to read files outside of the user's home directory.

Useful links:

Building Go snaps: https://docs.snapcraft.io/build-snaps/go

Publishing a snap package: https://docs.snapcraft.io/build-snaps/publish

You may want to publish release to the `stable` channel, and periodically publish the `HEAD` of the master branch to the `candidate` channel. This will allow users to choose which between stable and pre-release versions of `yq`.
