### PR TITLE
Add Dockerfile for building the official CLI container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.9 as builder
+
+RUN go get -u github.com/kardianos/govendor
+
+WORKDIR /go/src/mikefarah/yq
+
+COPY . /go/src/mikefarah/yq
+
+RUN govendor sync
+
+RUN CGO_ENABLED=0 go build
+
+# Choose alpine as a base image to make this useful for CI, as many
+# CI tools expect an interactive shell inside the container
+FROM alpine:3.7
+
+COPY --from=builder /go/src/mikefarah/yq/yq /usr/bin/yq
+RUN chmod +x /usr/bin/yq
+
+WORKDIR /workdir

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ or, [Download latest binary](https://github.com/mikefarah/yq/releases/latest) or
 go get github.com/mikefarah/yq
 ```
 
+## Run with Docker
+
+Oneshot use:
+
+```bash
+docker run -v ${PWD}:/workdir mikefarah/yq yq [flags] <command> FILE...
+```
+
+Run commands interactively:
+
+```bash
+docker run -it -v ${PWD}:/workdir mikefarah/yq sh
+```
+
 ## Features
 - Written in portable go, so you can download a lovely dependency free binary
 - Deep read a yaml file with a given path


### PR DESCRIPTION
Closes #126

This builds a minimal docker image from sources. It is suitable for use both as a oneshot command as well as an interactive shell.

To make full use of this, an automated build to Docker Hub should be added. Let me know if you need help with setting this up.