### PR TITLE
Adding a delete node command

### DIFF
--- a/data_navigator_test.go
+++ b/data_navigator_test.go
@@ -308,3 +308,80 @@ func TestWriteArray_no_paths(t *testing.T) {
 	result := writeArray(data, []string{}, 4)
 	assertResult(t, fmt.Sprintf("%v", data), fmt.Sprintf("%v", result))
 }
+
+func TestDelete_MapItem(t *testing.T) {
+	var data = parseData(`
+a: 123
+b: 456
+`)
+	var expected = parseData(`
+b: 456
+`)
+
+	result := deleteMap(data, []string{"a"})
+	assertResult(t, fmt.Sprintf("%v", expected), fmt.Sprintf("%v", result))
+}
+
+// Ensure deleting an index into a string does nothing
+func TestDelete_index_to_string(t *testing.T) {
+	var data = parseData(`
+a: mystring
+`)
+	result := deleteMap(data, []string{"a", "0"})
+	assertResult(t, fmt.Sprintf("%v", data), fmt.Sprintf("%v", result))
+}
+
+func TestDelete_list_index(t *testing.T) {
+	var data = parseData(`
+a: [3, 4]
+`)
+	var expected = parseData(`
+a: [3]
+`)
+	result := deleteMap(data, []string{"a", "1"})
+	assertResult(t, fmt.Sprintf("%v", expected), fmt.Sprintf("%v", result))
+}
+
+func TestDelete_list_index_beyond_bounds(t *testing.T) {
+	var data = parseData(`
+a: [3, 4]
+`)
+	result := deleteMap(data, []string{"a", "5"})
+	assertResult(t, fmt.Sprintf("%v", data), fmt.Sprintf("%v", result))
+}
+
+func TestDelete_list_index_out_of_bounds_by_1(t *testing.T) {
+	var data = parseData(`
+a: [3, 4]
+`)
+	result := deleteMap(data, []string{"a", "2"})
+	assertResult(t, fmt.Sprintf("%v", data), fmt.Sprintf("%v", result))
+}
+
+func TestDelete_no_paths(t *testing.T) {
+	var data = parseData(`
+a: [3, 4]
+b:
+  - name: test
+`)
+	result := deleteMap(data, []string{})
+	assertResult(t, fmt.Sprintf("%v", data), fmt.Sprintf("%v", result))
+}
+
+func TestDelete_array_map_item(t *testing.T) {
+	var data = parseData(`
+b:
+- name: fred
+  value: blah
+- name: john
+  value: test
+`)
+	var expected = parseData(`
+b:
+- value: blah
+- name: john
+  value: test
+`)
+	result := deleteMap(data, []string{"b", "0", "name"})
+	assertResult(t, fmt.Sprintf("%v", expected), fmt.Sprintf("%v", result))
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -41,19 +41,21 @@ func parseData(rawData string) yaml.MapSlice {
 }
 
 func assertResult(t *testing.T, expectedValue interface{}, actualValue interface{}) {
+	t.Helper()
 	if expectedValue != actualValue {
 		t.Error("Expected <", expectedValue, "> but got <", actualValue, ">", fmt.Sprintf("%T", actualValue))
 	}
 }
 
 func assertResultComplex(t *testing.T, expectedValue interface{}, actualValue interface{}) {
+	t.Helper()
 	if !reflect.DeepEqual(expectedValue, actualValue) {
 		t.Error("Expected <", expectedValue, "> but got <", actualValue, ">", fmt.Sprintf("%T", actualValue))
 	}
 }
 
 func assertResultWithContext(t *testing.T, expectedValue interface{}, actualValue interface{}, context interface{}) {
-
+	t.Helper()
 	if expectedValue != actualValue {
 		t.Error(context)
 		t.Error(": expected <", expectedValue, "> but got <", actualValue, ">")

--- a/yq_test.go
+++ b/yq_test.go
@@ -122,3 +122,11 @@ func TestNewYaml_WithUnknownScript(t *testing.T) {
 	expectedOutput := `open fake-unknown: no such file or directory`
 	assertResult(t, expectedOutput, err.Error())
 }
+
+func TestDeleteYaml(t *testing.T) {
+	result, _ := deleteYaml([]string{"examples/sample.yaml", "b.c"})
+	formattedResult := fmt.Sprintf("%v", result)
+	assertResult(t,
+		"[{a Easy! as one two three} {b [{d [3 4]} {e [[{name fred} {value 3}] [{name sam} {value 4}]]}]}]",
+		formattedResult)
+}


### PR DESCRIPTION
Implemented a `delete` command and associated tests for deleting a node from YAML input. This behaves in a similar manner as the `write` command.

The following functionality is not provided, although could conceivably be added with a modicum of additional effort if there is strong opinion that they are required:

 - Specify the node(s) to delete using a script (as with the `write` command)
 - Deleting common elements from all members of an array (deletions from individual members are supported using a path like `a.b[0].name`, but deleting from all instances in one pass, e.g. `a.b[*].name`, is not).

This may close #18, depending on opinion as to whether this is sufficient for providing the required  capability described by that issue.