### PR TITLE
Bump debian package version to 2.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+yq (2.0-1) bionic; urgency=medium
+
+  * Ability to read multiple documents in a single file
+  * Ability to append list items instead of overwriting
+
+ -- Roberto Mier Escandón <rmescandon@gmail.com>  Tue, 10 Jul 2018 14:02:42 +0200
+
 yq (2.0-0) bionic; urgency=medium
 
   * Release 2.0.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-yq (2.0-1) bionic; urgency=medium
+yq (2.1-0) bionic; urgency=medium
 
   * Ability to read multiple documents in a single file
   * Ability to append list items instead of overwriting


### PR DESCRIPTION
Here we go.
The package is already available in the ppa.

Aside note: Someday, when I got some spare time I'll investigate how this can be moved to the official Debian repositories (never published anything there before). That would be nice not having to add the PPA to have the package available :)

Fixes #159