### PR TITLE
add show comment features.

### DIFF
--- a/data_navigator.go
+++ b/data_navigator.go
@@ -7,6 +7,19 @@ import (
 	yaml "gopkg.in/mikefarah/yaml.v2"
 )
 
+func getRealIndex(array []interface{}, index int64) int64 {
+	for i, value := range array {
+		switch value.(type) {
+		case yaml.Comment:
+			index++
+		}
+		if int64(i) == index {
+			break
+		}
+	}
+	return index
+}
+
 func entryInSlice(context yaml.MapSlice, key interface{}) *yaml.MapItem {
 	for idx := range context {
 		var entry = &context[idx]
@@ -99,6 +112,7 @@ func writeArray(context interface{}, paths []string, value interface{}) []interf
 		index, _ = strconv.ParseInt(rawIndex, 10, 64) // nolint
 		// writeArray is only called by updatedChildValue which handles parsing the
 		// index, as such this renders this dead code.
+		index = getRealIndex(array, index)
 	}
 
 	for index >= int64(len(array)) {
@@ -164,6 +178,7 @@ func recurse(value interface{}, head string, tail []string) (interface{}, error)
 }
 
 func readArray(array []interface{}, head int64, tail []string) (interface{}, error) {
+	head = getRealIndex(array, head)
 	if head >= int64(len(array)) {
 		return nil, nil
 	}
@@ -249,6 +264,7 @@ func deleteArray(context interface{}, paths []string, index int64) interface{} {
 		return context
 	}
 
+	index = getRealIndex(array, index)
 	if index >= int64(len(array)) {
 		return array
 	}

--- a/yq.go
+++ b/yq.go
@@ -25,6 +25,7 @@ var overwriteFlag = false
 var appendFlag = false
 var verbose = false
 var version = false
+var commentEnable = false
 var docIndex = "0"
 var log = logging.MustGetLogger("yq")
 
@@ -99,6 +100,7 @@ yq r things.yaml a.array[*].blah
 	}
 	cmdRead.PersistentFlags().StringVarP(&docIndex, "doc", "d", "0", "process document index number (0 based, * for all documents)")
 	cmdRead.PersistentFlags().BoolVarP(&outputToJSON, "tojson", "j", false, "output as json")
+	cmdRead.Flags().BoolVarP(&commentEnable, "comment", "C", false, "Load comment enable.")
 	return cmdRead
 }
 
@@ -134,6 +136,7 @@ a.b.e:
 	cmdWrite.PersistentFlags().BoolVarP(&writeInplace, "inplace", "i", false, "update the yaml file inplace")
 	cmdWrite.PersistentFlags().StringVarP(&writeScript, "script", "s", "", "yaml script for updating yaml")
 	cmdWrite.PersistentFlags().StringVarP(&docIndex, "doc", "d", "0", "process document index number (0 based, * for all documents)")
+	cmdWrite.Flags().BoolVarP(&commentEnable, "comment", "C", false, "Load comment enable.")
 	return cmdWrite
 }
 
@@ -155,6 +158,7 @@ Outputs to STDOUT unless the inplace flag is used, in which case the file is upd
 	}
 	cmdDelete.PersistentFlags().BoolVarP(&writeInplace, "inplace", "i", false, "update the yaml file inplace")
 	cmdDelete.PersistentFlags().StringVarP(&docIndex, "doc", "d", "0", "process document index number (0 based, * for all documents)")
+	cmdDelete.Flags().BoolVarP(&commentEnable, "comment", "C", false, "Load comment enable.")
 	return cmdDelete
 }
 
@@ -223,6 +227,7 @@ func readProperty(cmd *cobra.Command, args []string) error {
 	if errorParsingDocIndex != nil {
 		return errorParsingDocIndex
 	}
+	yaml.DefaultCommentsEnable = commentEnable
 	var mappedDocs []interface{}
 	var dataBucket interface{}
 	var currentIndex = 0
@@ -377,6 +382,7 @@ func writeProperty(cmd *cobra.Command, args []string) error {
 	if errorParsingDocIndex != nil {
 		return errorParsingDocIndex
 	}
+	yaml.DefaultCommentsEnable = commentEnable
 
 	var updateData = func(dataBucket interface{}, currentIndex int) (interface{}, error) {
 		if updateAll || currentIndex == docIndexInt {
@@ -429,7 +435,7 @@ func deleteProperty(cmd *cobra.Command, args []string) error {
 	if errorParsingDocIndex != nil {
 		return errorParsingDocIndex
 	}
-
+	yaml.DefaultCommentsEnable = commentEnable
 	var updateData = func(dataBucket interface{}, currentIndex int) (interface{}, error) {
 		if updateAll || currentIndex == docIndexInt {
 			log.Debugf("Deleting path in doc %v", currentIndex)


### PR DESCRIPTION
Keep comments when changing yaml files.

### Example

data:
```
$ cat test.yaml
# An employee record
martin:
  name: Martin D'vloper
  # job data
  job: Developer
  skill: Elite


$ ./yq r test.yaml martin --comment
name: Martin D'vloper
# job data
job: Developer
skill: Elite

$ ./yq w test.yaml martin.test hello --comment
# An employee record
martin:
  name: Martin D'vloper
  # job data
  job: Developer
  skill: Elite
  test: hello
netpas: liu
```

[yaml support comment PR](https://github.com/mikefarah/yaml/pull/1)