### PR TITLE
Fix for Issue #180

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -847,7 +847,10 @@ c:
 
 func TestMergeCmd_Inplace(t *testing.T) {
 	filename := writeTempYamlFile(readTempYamlFile("examples/data1.yaml"))
-	os.Chmod(filename, os.FileMode(int(0666)))
+	err := os.Chmod(filename, os.FileMode(int(0666)))
+	if err != nil {
+		t.Error(err)
+	}
 	defer removeTempYamlFile(filename)
 
 	cmd := getRootCommand()

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -600,7 +601,7 @@ b:
 func TestDeleteYamlArray(t *testing.T) {
 	content := `- 1
 - 2
-- 3	
+- 3
 `
 	filename := writeTempYamlFile(content)
 	defer removeTempYamlFile(filename)
@@ -846,6 +847,7 @@ c:
 
 func TestMergeCmd_Inplace(t *testing.T) {
 	filename := writeTempYamlFile(readTempYamlFile("examples/data1.yaml"))
+	os.Chmod(filename, os.FileMode(int(0666)))
 	defer removeTempYamlFile(filename)
 
 	cmd := getRootCommand()
@@ -853,6 +855,7 @@ func TestMergeCmd_Inplace(t *testing.T) {
 	if result.Error != nil {
 		t.Error(result.Error)
 	}
+	info, _ := os.Stat(filename)
 	gotOutput := readTempYamlFile(filename)
 	expectedOutput := `a: simple
 b:
@@ -861,4 +864,5 @@ b:
 c:
   test: 1`
 	assertResult(t, expectedOutput, strings.Trim(gotOutput, "\n "))
+	assertResult(t, os.FileMode(int(0666)), info.Mode())
 }

--- a/yq.go
+++ b/yq.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 
 	errors "github.com/pkg/errors"
-	"gopkg.in/spf13/cobra.v0"
 
 	yaml "gopkg.in/mikefarah/yaml.v2"
 	logging "gopkg.in/op/go-logging.v1"
+	cobra "gopkg.in/spf13/cobra.v0"
 )
 
 var trimOutput = true
@@ -398,7 +398,15 @@ func readAndUpdate(stdOut io.Writer, inputFile string, updateData updateDataFn) 
 	var destination io.Writer
 	var destinationName string
 	if writeInplace {
-		var tempFile, err = ioutil.TempFile("", "temp")
+		info, err := os.Stat(inputFile)
+		if err != nil {
+			return err
+		}
+		tempFile, err := ioutil.TempFile("", "temp")
+		if err != nil {
+			return err
+		}
+		err = tempFile.Chmod(info.Mode())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A quick fix to copy the original YAML file permissions to the temp file created during an inline merge.