### PR TITLE
Bump Alpine version to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 make local build
 
 # Choose alpine as a base image to make this useful for CI, as many
 # CI tools expect an interactive shell inside the container
-FROM alpine:3.7 as production
+FROM alpine:3.8 as production
 
 COPY --from=builder /go/src/mikefarah/yq/yq /usr/bin/yq
 RUN chmod +x /usr/bin/yq


### PR DESCRIPTION
There has been a security issue with older Alpine versions and their package manager.
https://justi.cz/security/2018/09/13/alpine-apk-rce.html

Not sure about 3.7, but the latest 3.8 image has it fixed.