### PR TITLE
Fix Debian 'Architecture'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Vcs-Browser: https://github.com/mikefarah/yq.git
 Vcs-Git: https://github.com/mikefarah/yq.git
 
 Package: yq
-Architecture: all
+Architecture: any
 Built-Using: ${misc:Built-Using}
 Depends: ${shlibs:Depends},
          ${misc:Depends}


### PR DESCRIPTION
When it's 'all', architecture-independent packages are built, and so now an x86_64 executable is packaged to noarch packaged.