### PR TITLE
Add spec file for RPM systems

### DIFF
--- a/redhat/yq.spec
+++ b/redhat/yq.spec
@@ -56,5 +56,5 @@ install -p -m 755 gopath/src/github.com/%{git_org}/%{name}/%{name} %{buildroot}%
 %{_bindir}/%{name}
 
 %changelog
-* Mon Mar 25 2019 Bradford Dabbs <brad@perched.io>
+* Mon Mar 25 2019 Bradford Dabbs <brad@perched.io> 2.3.0-1
  - Initial creation of spec file

--- a/redhat/yq.spec
+++ b/redhat/yq.spec
@@ -12,7 +12,8 @@ License:        MIT
 URL:            https://github.com/%{git_org}/%{name}
 Source0:        https://github.com/%{git_org}/%{name}/archive/%{version}.tar.gz
 
-BuildRequires:  golang rsync
+BuildRequires:  golang
+BuildRequires:  rsync
 
 %description
 yq is a lightweight and portable command-line YAML processor.
@@ -49,6 +50,8 @@ install -p -m 755 gopath/src/github.com/%{git_org}/%{name}/%{name} %{buildroot}%
 
 %files
 %doc README.md LICENSE
+
+%license LICENSE
 
 %{_bindir}/%{name}
 

--- a/redhat/yq.spec
+++ b/redhat/yq.spec
@@ -1,0 +1,57 @@
+%global git_org mikefarah
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12
+%global _dwz_low_mem_die_limit 0
+
+Name:           yq
+Version:        2.3.0
+Release:        1%{?dist}
+Summary:        Process YAML documents from the CLI
+
+License:        MIT
+URL:            https://github.com/%{git_org}/%{name}
+Source0:        https://github.com/%{git_org}/%{name}/archive/%{version}.tar.gz
+
+BuildRequires:  golang rsync
+
+%description
+yq is a lightweight and portable command-line YAML processor.
+
+The aim of the project is to be the jq or sed of yaml files.
+
+
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+
+mkdir -p gopath/src/github.com/%{git_org}/%{name}
+export GOPATH=${PWD}/gopath
+export PATH=${GOPATH}:${PATH}
+rsync -az --exclude=gopath/ ./ gopath/src/github.com/%{git_org}/%{name}
+cd gopath/src/github.com/%{git_org}/%{name}
+
+# Get go dependencies
+go get -u github.com/kardianos/govendor
+go install github.com/kardianos/govendor
+
+# Build the yq binary
+${GOPATH}/bin/govendor sync
+go build -o %{name} -ldflags=-linkmode=external
+
+%install
+rm -rf %{buildroot}
+
+# Install binaries & scripts
+install -d %{buildroot}%{_bindir}
+install -p -m 755 gopath/src/github.com/%{git_org}/%{name}/%{name} %{buildroot}%{_bindir}
+
+%files
+%doc README.md LICENSE
+
+%{_bindir}/%{name}
+
+%changelog
+* Mon Mar 25 2019 Bradford Dabbs <brad@perched.io>
+ - Initial creation of spec file


### PR DESCRIPTION
This PR adds `redhat/yq.spec`, which can be used to generate RPMs for use on RedHat/CentOS based systems. 

You will still need to integrate with a pipeline to do the actual RPM build. I have tested this process manually with rpmbuild and automatically using COPR. You can see the artifacts of a successful COPR build here: https://copr-be.cloud.fedoraproject.org/results/bndabbs/rocknsm-devel_brad/epel-7-x86_64/00873831-yq/

```
┌─ [~]
└─▪ yum info yq
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.compevo.com
 * extras: mirror.linuxfix.com
 * updates: mirror.fileplanet.com
Installed Packages
Name        : yq
Arch        : x86_64
Version     : 2.3.0
Release     : 1.el7
Size        : 3.7 M
Repo        : installed
Summary     : Process YAML documents from the CLI
URL         : https://github.com/mikefarah/yq
License     : MIT
Description : yq is a lightweight and portable command-line YAML processor.
            :
            : The aim of the project is to be the jq or sed of yaml files.

┌─ [~]
└─▪ yq
Usage:
  yq [flags]
  yq [command]

Available Commands:
  delete      yq d [--inplace/-i] [--doc/-d index] sample.yaml a.b.c
  help        Help about any command
  merge       yq m [--inplace/-i] [--doc/-d index] [--overwrite/-x] [--append/-a] sample.yaml sample2.yaml
  new         yq n [--script/-s script_file] a.b.c newValue
  prefix      yq p [--inplace/-i] [--doc/-d index] sample.yaml a.b.c
  read        yq r [--doc/-d index] sample.yaml a.b.c
  write       yq w [--inplace/-i] [--script/-s script_file] [--doc/-d index] sample.yaml a.b.c newValue

Flags:
  -h, --help      help for yq
  -t, --trim      trim yaml output (default true)
  -v, --verbose   verbose mode
  -V, --version   Print version information and quit

Use "yq [command] --help" for more information about a command.
```
