### PR TITLE
Stop treating top-level values specially

### DIFF
--- a/yq.go
+++ b/yq.go
@@ -600,12 +600,7 @@ func toString(context interface{}) (string, error) {
 }
 
 func yamlToString(context interface{}) (string, error) {
-	switch context := context.(type) {
-	case string:
-		return context, nil
-	default:
-		return marshalContext(context)
-	}
+	return marshalContext(context)
 }
 
 func marshalContext(context interface{}) (string, error) {


### PR DESCRIPTION
Before applying this change,
```
$ go build
$ ./yq r - <<<'"true"'
```
returns `true`, which is probably an unexpected behavior (because YAML treats `true` specially.)
After applying this change, the command above returns `"true"`, which is identical to the input YAML.