### PR TITLE
Chocolatey package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ parts/
 prime/
 .snapcraft/
 yq*.snap
+
+# choco
+*.nupkg

--- a/choco/tools/chocolateyinstall.ps1
+++ b/choco/tools/chocolateyinstall.ps1
@@ -1,0 +1,14 @@
+﻿$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$packageArgs = @{
+    PackageName    = 'yq'
+    Url            = 'https://github.com/mikefarah/yq/releases/download/2.4.1/yq_windows_386.exe'
+    Checksum       = '7ED72DF0565DC08481101DC5B5E00FC071791189541803F71BDD1BEB7FE90522'
+    ChecksumType   = 'sha256'
+    Url64bit       = 'https://github.com/mikefarah/yq/releases/download/2.4.1/yq_windows_amd64.exe'
+    Checksum64     = 'BDFD2A00BAB3D8171EDF57AAF4E9A2F7D0395E7A36D42B07F0E35503C00292A3'
+    ChecksumType64 = 'sha256'
+    FileFullPath   = "$toolsDir\yq.exe"
+}
+
+Get-ChocolateyWebFile @packageArgs

--- a/choco/yq.nuspec
+++ b/choco/yq.nuspec
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>yq</id>
+    <version>2.4.1</version>
+    <packageSourceUrl>https://github.com/mikefarah/yq/tree/master/choco</packageSourceUrl>
+    <owners>Mike Farah</owners>
+    <title>yq</title>
+    <authors>Mike Farah</authors>
+    <projectUrl>http://mikefarah.github.io/yq/</projectUrl>
+    <copyright>2017 Mike Farah</copyright>
+    <licenseUrl>https://github.com/mikefarah/yq/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/mikefarah/yq</projectSourceUrl>
+    <docsUrl>http://mikefarah.github.io/yq/</docsUrl>
+    <bugTrackerUrl>https://github.com/mikefarah/yq/issues</bugTrackerUrl>
+    <tags>yq yaml</tags>
+    <summary>yq is a portable command-line YAML processor</summary>
+    <description>The aim of the project is to be the jq or sed of yaml files.</description>
+    <releaseNotes>https://github.com/mikefarah/yq/releases</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+    <!-- When building on Linux you may need instead -->
+    <!-- <file src="tools/**" target="tools" /> -->
+  </files>
+</package>


### PR DESCRIPTION
Hi Mike,

This PR includes package spec for Chocolatey, as per our email discussion.

To build the package on Linux:
* I'm not sure if you need PowerShell at all, but I think you need mono and chocolatey for this, my google-fu gave only [this link](https://stackoverflow.com/questions/39386471/can-i-build-chocolatey-packages-on-linux)
* navigate to `choco` directory and execute something like `mono /path/to/choco.exe pack yq.nuspec`. it will either work, or not. if not, consider changing the `tools` path in the `.nuspec` file (see comment).
* when it works, it will output `yq.2.4.1.nupkg` file, send it to me for verification to be sure everything is okay

after we're done with it, basically two more things to mention:

1. publishing a package. sign up on [chocolatey community packages](https://chocolatey.org/packages) and basically just submit the `yq.2.4.1.nupkg` file through web UI. there's also a CLI helper for that step (`choco push`).
2. if you will release a new version, change `version` in `.nuspec`, `Url`, `Url64`, `Url64bit` and `Checksum64` in `.ps1`. then pack, then push.

I believe, that's it. Drop me a note with the resulting `.nupkg` and whether I need to update `tools` path in the `.nuspec` (I'll update the PR if you won't do it already).

P.S. this PR does not document `choco` installation yet, let's get a package submitted and only then document this way of installing.