### PR TITLE
Fix path generation when merging file has period in key

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -1262,7 +1262,7 @@ c:
   toast: leave
   test: 1
   tell: 1
-  taco: cool
+  tasty.taco: cool
 `
 	filename := test.WriteTempYamlFile(content)
 	defer test.RemoveTempYamlFile(filename)
@@ -1277,7 +1277,7 @@ c:
 b: [3, 4]
 c:
   toast: leave
-  taco: cool
+  tasty.taco: cool
 `
 	test.AssertResult(t, expectedOutput, result.Output)
 }
@@ -1443,7 +1443,7 @@ c:
   test: 1
   toast: leave
   tell: 1
-  taco: cool
+  tasty.taco: cool
 `
 	test.AssertResult(t, expectedOutput, result.Output)
 }
@@ -1644,7 +1644,7 @@ c:
   test: 1
   toast: leave
   tell: 1
-  taco: cool
+  tasty.taco: cool
 `
 	test.AssertResult(t, expectedOutput, gotOutput)
 	test.AssertResult(t, os.FileMode(int(0666)), info.Mode())

--- a/examples/data2.yaml
+++ b/examples/data2.yaml
@@ -4,4 +4,4 @@ c:
   toast: leave
   test: 1
   tell: 1
-  taco: cool
+  tasty.taco: cool

--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -51,7 +51,15 @@ func mergePathStackToString(pathStack []interface{}, appendArrays bool) string {
 			}
 
 		default:
-			sb.WriteString(fmt.Sprintf("%v", path))
+			s := fmt.Sprintf("%v", path)
+			hasDot := strings.Contains(s, ".")
+			if hasDot {
+				sb.WriteString("[")
+			}
+			sb.WriteString(s)
+			if hasDot {
+				sb.WriteString("]")
+			}
 		}
 
 		if index < len(pathStack)-1 {


### PR DESCRIPTION
The program generates a path for every leaf node in the
file-to-be-merged. It does not escape them if they contain a dot, as
the path-expressions document mentions is necessary.

Add in a test for this condition. Verified it fails without the fix.