### PR TITLE
docs(readme): protect parameter expansions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,20 @@ GO111MODULE=on go get github.com/mikefarah/yq/v3
 Oneshot use:
 
 ```bash
-docker run --rm -v ${PWD}:/workdir mikefarah/yq yq [flags] <command> FILE...
+docker run --rm -v "${PWD}":/workdir mikefarah/yq yq [flags] <command> FILE...
 ```
 
 Run commands interactively:
 
 ```bash
-docker run --rm -it -v ${PWD}:/workdir mikefarah/yq sh
+docker run --rm -it -v "${PWD}":/workdir mikefarah/yq sh
 ```
 
 It can be useful to have a bash function to avoid typing the whole docker command:
 
 ```bash
 yq() {
-  docker run --rm -i -v ${PWD}:/workdir mikefarah/yq yq $@
+  docker run --rm -i -v "${PWD}":/workdir mikefarah/yq yq "$@"
 }
 ```
 


### PR DESCRIPTION
Hi.

The Readme’s Bash function example might cause issues (and head-scratching) due to how its parameters are handled.

From `man bash`:

> "$@" is equivalent to "$1" "$2" ...

Example:

```bash
  $ function quoted { printf '%s\n' "$@"; }
# ≠
  $ function unquoted { printf '%s\n' $@; }

  $ quoted 1 '2 3' 4
1
2 3
4

  $ unquoted 1 '2 3' 4
1
2 ← Unwanted split into two words.
3 ↙
4
```

(It gets even worse when people start fiddling with the value of IFS.)