### PR TITLE
mk TempDir

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -423,6 +423,14 @@ func readAndUpdate(stdOut io.Writer, inputFile string, updateData updateDataFn) 
 		if err != nil {
 			return err
 		}
+		// mkdir temp dir as some docker images does not have temp dir
+		_, err = os.Stat(os.TempDir())
+		if os.IsNotExist(err) {
+			err = os.Mkdir(os.TempDir(), 0700)
+			if err != nil {
+				return err
+			}
+		}
 		tempFile, err := ioutil.TempFile("", "temp")
 		if err != nil {
 			return err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -430,6 +430,8 @@ func readAndUpdate(stdOut io.Writer, inputFile string, updateData updateDataFn) 
 			if err != nil {
 				return err
 			}
+		} else if err != nil {
+			return err
 		}
 		tempFile, err := ioutil.TempFile("", "temp")
 		if err != nil {


### PR DESCRIPTION
in some docker images, such as busybox.
There may not be a tmp directory, so we will try to create it if it does not exist.