### PR TITLE
Set entrypoint for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,4 @@ ARG VERSION=none
 LABEL version=${VERSION}
 
 WORKDIR /workdir
+ENTRYPOINT ["/usr/bin/yq"]


### PR DESCRIPTION
With this the image can be run without "yq" but directly passing arguments instead.

This is a breaking change since existing commands will now fail due to "yq yq" being invalid.

See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint