### PR TITLE
Releasing multi-arch images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Publish image to Dockerhub
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    env:
+      IMAGE_NAME: mikefarah/yq
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest release tag      
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: mikefarah/yq  # The repository to scan.
+          releases-only: true  # We know that all relevant tags have a GitHub release for them.
+        id: yq  
+        
+      - name: Clone source code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.yq.outputs.tag }}
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+  
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }} && docker version
+ 
+      - name: Build and push image
+        run: |
+          IMAGE_VERSION="$(git describe --tags --abbrev=0)"
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64"
+          echo "Building and pushing version ${IMAGE_VERSION} of image ${IMAGE_NAME}"
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker buildx build --platform "${PLATFORMS}" -t "${IMAGE_NAME}:${IMAGE_VERSION}"  -t "${IMAGE_NAME}:latest" \
+            --push .
+    

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-./bin/golangci-lint run
+./bin/golangci-lint run --timeout=5m
 
 # ./bin/golangci-lint \
 #   --tests \


### PR DESCRIPTION
This PR resolves https://github.com/mikefarah/yq/issues/555. Taking advantage of github release action, whenever a new version is released, the workflow will be triggered which creates and pushes multi-arch image for the latest released version to dockerhub. Currently I have added support for amd64, ppc64le & arm64 & tested on ppc64le. As buildx and QEMU is used, it can be easily extended for other architectures.

A sample run logs are available at - https://github.com/bahetiamit/yq/runs/1361864312?check_suite_focus=true and resulting images are at https://hub.docker.com/repository/docker/bahetiamit/yq/tags?page=1

This workflow needs two secrets to be setup on this github repo i.e. _DOCKER_USERNAME_ and _DOCKER_PASSWORD_ to be able to login to dockerhub and push the images.