### PR TITLE
#607 Fix string value with spaces error

### DIFF
--- a/pkg/yqlib/operator_assign_test.go
+++ b/pkg/yqlib/operator_assign_test.go
@@ -13,6 +13,13 @@ var assignOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
+		description: "Create yaml file with value with spaces",
+		expression:  `.a.b = "cat" | .x = "frog jumps"`,
+		expected: []string{
+			"D0, P[], ()::a:\n    b: cat\nx: frog jumps\n",
+		},
+	},
+	{
 		description: "Update node to be the child value",
 		document:    `{a: {b: {g: foof}}}`,
 		expression:  `.a |= .b`,

--- a/pkg/yqlib/path_tokeniser.go
+++ b/pkg/yqlib/path_tokeniser.go
@@ -250,7 +250,7 @@ func initLexer() (*lex.Lexer, error) {
 	lexer.Add([]byte(`[Nn][Uu][Ll][Ll]`), nullValue())
 	lexer.Add([]byte(`~`), nullValue())
 
-	lexer.Add([]byte(`"[^ "]*"`), stringValue(true))
+	lexer.Add([]byte(`"[^"]*"`), stringValue(true))
 
 	lexer.Add([]byte(`\[\]`), literalToken(SplatOrEmptyCollect, true))
 


### PR DESCRIPTION
Fixes #607 
I've added one more test that produces documentation entry.

The reason behind excluding space inside `"..."` is unknown to me, but since all tests are passing I think we are good. If needed, I can go a bit more into implementation to figure out a better solution.

By examining https://github.com/timtadh/lexmachine#adding-a-pattern I found that it is safe to remove that space from the regex exclude group since `lexer.Add([]byte(` `), token("SPACE"))` is not an option for YQ.
 