### PR TITLE
find golangci_lint through PATH

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,7 @@ COPY scripts/devtools.sh /opt/devtools.sh
 
 RUN set -e -x \
     && /opt/devtools.sh
+ENV PATH=/go/bin:$PATH
 
 # install mkdocs
 RUN set -ex \

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-./bin/golangci-lint run --timeout=5m
+golangci-lint run --timeout=5m
 
 # ./bin/golangci-lint \
 #   --tests \


### PR DESCRIPTION
Addresses issue #619 - make fails....

Adds /go/bin to PATH env variable in Dockerfile.dev and modifies  scripts/check.sh to search PATH instead of running golangci-lint directly via relative path.