### PR TITLE
added EvaluateNodes and EvaluateCandidateNodes to yqlib

### DIFF
--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -166,6 +166,24 @@ func NodeToString(node *CandidateNode) string {
 	return fmt.Sprintf(`D%v, P%v, (%v)::%v`, node.Document, node.Path, tag, buf.String())
 }
 
+// EvaluateNodes takes an expression and one or more yaml nodes, returning a list of matching candidate nodes
+func EvaluateNodes(expression string, nodes ...*yaml.Node) (*list.List, error) {
+	inputCandidates := list.New()
+	for _, node := range nodes {
+		inputCandidates.PushBack(&CandidateNode{Node: node})
+	}
+	return EvaluateCandidateNodes(expression, inputCandidates)
+}
+
+// EvaluateCandidateNodes takes an expression and list of candidate nodes, returning a list of matching candidate nodes
+func EvaluateCandidateNodes(expression string, inputCandidates *list.List) (*list.List, error) {
+	node, err := treeCreator.ParsePath(expression)
+	if err != nil {
+		return nil, err
+	}
+	return treeNavigator.GetMatchingNodes(inputCandidates, node)
+}
+
 func KindString(kind yaml.Kind) string {
 	switch kind {
 	case yaml.ScalarNode:

--- a/pkg/yqlib/lib_test.go
+++ b/pkg/yqlib/lib_test.go
@@ -1,0 +1,39 @@
+package yqlib
+
+import (
+	"testing"
+
+	"github.com/mikefarah/yq/v4/test"
+)
+
+var evaluateNodesScenario = []expressionScenario{
+	{
+		document:   `a: hello`,
+		expression: `.a`,
+		expected: []string{
+			"D0, P[a], (!!str)::hello\n",
+		},
+	},
+	{
+		document:   `a: hello`,
+		expression: `.`,
+		expected: []string{
+			"D0, P[], (doc)::a: hello\n",
+		},
+	},
+	{
+		document:   `- a: "yes"`,
+		expression: `.[] | has("a")`,
+		expected: []string{
+			"D0, P[0], (!!bool)::true\n",
+		},
+	},
+}
+
+func TestEvaluateNodesScenarios(t *testing.T) {
+	for _, tt := range evaluateNodesScenario {
+		node := test.ParseData(tt.document)
+		list, _ := EvaluateNodes(tt.expression, &node)
+		test.AssertResultComplex(t, tt.expected, resultsToString(list))
+	}
+}


### PR DESCRIPTION
In an attempt to reproduce v3 yqlib's  `Get`
```go
Yqlib.Get(rootNode *yaml.Node, path string) ([]*NodeContext, error)
```

Two functions have been added:
* `func EvaluateNodes(expression string, nodes ...*yaml.Node) (*list.List, error)`
* `func EvaluateCandidateNodes(expression string, inputCandidates *list.List) (*list.List, error)`


This attempts to address the feature suggested in https://github.com/mikefarah/yq/issues/640

