### PR TITLE
Don't escape HTML chars when converting to json

### DIFF
--- a/pkg/yqlib/encoder.go
+++ b/pkg/yqlib/encoder.go
@@ -76,6 +76,8 @@ func mapKeysToStrings(node *yaml.Node) {
 
 func NewJsonEncoder(destination io.Writer, indent int) Encoder {
 	var encoder = json.NewEncoder(destination)
+	encoder.SetEscapeHTML(false) // do not escape html chars e.g. &, <, >
+
 	var indentString = ""
 
 	for index := 0; index < indent; index++ {
@@ -153,11 +155,15 @@ func (o *orderedMap) UnmarshalJSON(data []byte) error {
 }
 
 func (o orderedMap) MarshalJSON() ([]byte, error) {
-	if o.kv == nil {
-		return json.Marshal(o.altVal)
-	}
 	buf := new(bytes.Buffer)
 	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false) // do not escape html chars e.g. &, <, >
+	if o.kv == nil {
+		if err := enc.Encode(o.altVal); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
 	buf.WriteByte('{')
 	for idx, el := range o.kv {
 		if err := enc.Encode(el.K); err != nil {

--- a/pkg/yqlib/encoder_test.go
+++ b/pkg/yqlib/encoder_test.go
@@ -9,29 +9,11 @@ import (
 	"github.com/mikefarah/yq/v4/test"
 )
 
-var sampleYaml = `zabbix: winner
-apple: great
-banana:
-- {cobra: kai, angus: bob}
-`
-
-var expectedJson = `{
-  "zabbix": "winner",
-  "apple": "great",
-  "banana": [
-    {
-      "cobra": "kai",
-      "angus": "bob"
-    }
-  ]
-}
-`
-
-func TestJsonEncoderPreservesObjectOrder(t *testing.T) {
+func yamlToJson(sampleYaml string, indent int) string {
 	var output bytes.Buffer
 	writer := bufio.NewWriter(&output)
 
-	var jsonEncoder = NewJsonEncoder(writer, 2)
+	var jsonEncoder = NewJsonEncoder(writer, indent)
 	inputs, err := readDocuments(strings.NewReader(sampleYaml), "sample.yml", 0)
 	if err != nil {
 		panic(err)
@@ -42,6 +24,33 @@ func TestJsonEncoderPreservesObjectOrder(t *testing.T) {
 		panic(err)
 	}
 	writer.Flush()
-	test.AssertResult(t, expectedJson, output.String())
 
+	return strings.TrimSuffix(output.String(), "\n")
+}
+
+func TestJsonEncoderPreservesObjectOrder(t *testing.T) {
+	var sampleYaml = `zabbix: winner
+apple: great
+banana:
+- {cobra: kai, angus: bob}
+`
+	var expectedJson = `{
+  "zabbix": "winner",
+  "apple": "great",
+  "banana": [
+    {
+      "cobra": "kai",
+      "angus": "bob"
+    }
+  ]
+}`
+	var actualJson = yamlToJson(sampleYaml, 2)
+	test.AssertResult(t, expectedJson, actualJson)
+}
+
+func TestJsonEncoderDoesNotEscapeHTMLChars(t *testing.T) {
+	var sampleYaml = `build: "( ./lint && ./format && ./compile ) < src.code"`
+	var expectedJson = `{"build":"( ./lint && ./format && ./compile ) < src.code"}`
+	var actualJson = yamlToJson(sampleYaml, 0)
+	test.AssertResult(t, expectedJson, actualJson)
 }


### PR DESCRIPTION
Hi Mike, love the tool. Being able to do things like complex document merges with short expressions is simply awesome.

I'm working with json/yaml conversion with configs that often include `<` `>` `&` chars, and it took me a bit of time to figure out why these were being escaped in json output:
```
$ echo "<&>: <&>" | yq eval
<&>: <&>
$ echo "<&>: <&>" | yq eval --tojson
{
  "\u003c\u0026\u003e": "\u003c\u0026\u003e"
}
```
Turns out this behavior is coming from golang's json.Encoder and json.Marshal. Commit message describes the issue/resolution:

> json.Encoder and json.Marshal implicitly use HTMLEscape to convert
>, <, &, with \u003c, \u003e, \u0026. This behavior carries over
to yq, where chars will be escaped when outputting json but not when
outputting yaml.

> This patch disables this behavior via encoder.SetEscapeHTML(false).
Unfortunately there is no equivalent option for json.Marshal, so its
single usage has been replaced with an encoder (with escaping disabled).

Hopefully this updated behavior improves consistency (wrt. json vs yaml output). I could also see potential usefulness of an option to escape these chars when using yq in a web/browser context, but in that case it should probably affect the behavior for both yaml and json output. Let me know if controlling this via an option would be preferable and I'd be happy to update the functionality here.

I was mildly concerned about the switch from Marshal -> Encode below having some affect on performance, so I did some (very basic) benchmarking. Not seeing any negative impact running on a >100MB yaml file (on a 2015 macbook air).
```
 yq ● ls ~/sample.yml
.rw-r--r-- 138M evan 17 Jan  9:16 /Users/evan/sample.yml
 yq ● git rev-parse --abbrev-ref HEAD
master
 yq ● go build
 yq ● time ./yq eval --tojson < ~/sample.yml > ~/sample.json

real	0m14.569s
user	0m16.491s
sys	0m1.184s
 yq ● time ./yq eval --tojson < ~/sample.yml > ~/sample.json

real	0m15.878s
user	0m18.408s
sys	0m2.880s
 yq ● time ./yq eval --tojson < ~/sample.yml > ~/sample.json

real	0m14.365s
user	0m16.046s
sys	0m1.347s
 yq ● git checkout tojson-prevent-html-escaping
Switched to branch 'tojson-prevent-html-escaping'
 yq ● go build
 yq ● time ./yq eval --tojson < ~/sample.yml > ~/sample.json

real	0m15.206s
user	0m17.498s
sys	0m1.184s
 yq ● time ./yq eval --tojson < ~/sample.yml > ~/sample1.json

real	0m14.607s
user	0m16.928s
sys	0m1.197s
 yq ● time ./yq eval --tojson < ~/sample.yml > ~/sample1.json

real	0m14.774s
user	0m17.986s
sys	0m1.639s

```

Thank you all the work on yq, it's a fantastic tool. Hope this patch is helpful. 