### PR TITLE
fix: go install fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ yq() {
 
 ### Go Get:
 ```
-GO111MODULE=on go get github.com/mikefarah/yq
+GO111MODULE=on go get github.com/mikefarah/yq@master
 ```
 
 ## Community Supported Installation methods

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ yq() {
 
 ### Go Get:
 ```
-GO111MODULE=on go get github.com/mikefarah/yq@master
+GO111MODULE=on go get github.com/mikefarah/yq/v4
 ```
 
 ## Community Supported Installation methods


### PR DESCRIPTION
Installation by go will result in an error:
```bash
$ GO111MODULE=on go get github.com/mikefarah/yq
go get: gopkg.in/mikefarah/yaml.v2@none updating to
	gopkg.in/mikefarah/yaml.v2@v2.4.0: parsing go.mod:
	module declares its path as: github.com/mikefarah/yaml/v2
	        but was required as: gopkg.in/mikefarah/yaml.v2
```

Go install with master branch will fix it.

fix: #676