### PR TITLE
Fix pretty-printing

### DIFF
--- a/cmd/evalute_sequence_command.go
+++ b/cmd/evalute_sequence_command.go
@@ -102,7 +102,7 @@ func evaluateSequence(cmd *cobra.Command, args []string) error {
 			err = streamEvaluator.EvaluateFiles(processExpression(""), []string{args[0]}, printer)
 		}
 	default:
-		err = streamEvaluator.EvaluateFiles(args[0], args[1:], printer)
+		err = streamEvaluator.EvaluateFiles(processExpression(args[0]), args[1:], printer)
 	}
 	completedSuccessfully = err == nil
 


### PR DESCRIPTION
I think this is all that's required for these two issues.

Fixes #716 and #715

```
$ cat data1.yml
this: []
$ go run yq.go eval --prettyPrint '.this += 1' data1.yml
this:
  - 1
$ cat data2.yml
foo: [1,2,3]
$ go run yq.go eval --prettyPrint data2.yml
foo:
  - 1
  - 2
  - 3
```