### PR TITLE
Add `with_entries` example using filtering

### DIFF
--- a/pkg/yqlib/doc/Entries.md
+++ b/pkg/yqlib/doc/Entries.md
@@ -98,3 +98,19 @@ KEY_a: 1
 KEY_b: 2
 ```
 
+Using with_entries is also useful whe you want to filter a map. Given a sample.yml file of:
+```yaml
+a:
+  b: bird
+c:
+  d: dog
+```
+then
+```bash
+yq eval 'with_entries(select(.value | has("b")))' sample.yml
+```
+will output
+```yaml
+a:
+  b: bird
+```

--- a/pkg/yqlib/operator_entries_test.go
+++ b/pkg/yqlib/operator_entries_test.go
@@ -52,6 +52,14 @@ var entriesOperatorScenarios = []expressionScenario{
 			"D0, P[], (!!map)::KEY_a: 1\nKEY_b: 2\n",
 		},
 	},
+	{
+		description: "Use with_entries to filter keys",
+		document:    `{a: b: "bird", c: d: "dog"}`,
+		expression:  `with_entries(.value | has("b"))`,
+		expected: []string{
+			"D0, P[], (!!map)::a:\n  b: \"bird\"\n",
+		},
+	},
 }
 
 func TestEntriesOperatorScenarios(t *testing.T) {


### PR DESCRIPTION
Adds an additional example to `with_entries` for a use case I wasn't finding any better way to accomplish.

I also think it's worth mentioning here that `with_entries(foo)` is equivalent to `to_entries | map(foo) | from_entries` like the [`jq` manual mentions](https://stedolan.github.io/jq/manual/#Builtinoperatorsandfunctions).