### PR TITLE
Update Dockerfile to use Alpine 3.15.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 make local build
 
 # Choose alpine as a base image to make this useful for CI, as many
 # CI tools expect an interactive shell inside the container
-FROM alpine:3.12.3 as production
+FROM alpine:3.13.5 as production
 
 COPY --from=builder /go/src/mikefarah/yq/yq /usr/bin/yq
 RUN chmod +x /usr/bin/yq


### PR DESCRIPTION
Alpine 3.15.5 has fixes for CVE-2021-30139, CVE-2021-28831, CVE-2021-23840, and CVE-2021-3450