### PR TITLE
Checksum archives as well as binaries

### DIFF
--- a/scripts/xcompile.sh
+++ b/scripts/xcompile.sh
@@ -7,11 +7,12 @@ set -e
 CGO_ENABLED=0 gox -ldflags "${LDFLAGS}" -output="build/yq_{{.OS}}_{{.Arch}}" --osarch="darwin/amd64 darwin/arm64 freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm linux/arm64 linux/mips linux/mips64 linux/mips64le linux/mipsle linux/ppc64 linux/ppc64le linux/s390x netbsd/386 netbsd/amd64 netbsd/arm openbsd/386 openbsd/amd64 windows/386 windows/amd64"
 
 cd build
+
+find . -executable -type f | xargs -I {} tar czvf {}.tar.gz {}
+
 rhash -r -a . -o checksums
 
 rhash --list-hashes > checksums_hashes_order
-
-find . -executable -type f | xargs -I {} tar czvf {}.tar.gz {}
 
 # just in case find thinks this is executable...
 rm -f checksums_hashes_order.tar.gz 


### PR DESCRIPTION
Often, checksums are based on the archive files. This gives some measure of confidence that the file won't exploit a tar or zip vulnerability.