### PR TITLE
Draft: Fix medium and low gosec vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/timtadh/data-structures v0.5.3 // indirect
 	github.com/timtadh/lexmachine v0.2.2
-	golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e h1:XNp2Flc/1eWQGk5BLzqTAN7fQIwIbfyVTuVxXxZh73M=
-golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/yqlib/file_utils.go
+++ b/pkg/yqlib/file_utils.go
@@ -3,6 +3,7 @@ package yqlib
 import (
 	"io"
 	"os"
+	"path/filepath"
 )
 
 func safelyRenameFile(from string, to string) {
@@ -25,7 +26,7 @@ func safelyRenameFile(from string, to string) {
 
 // thanks https://stackoverflow.com/questions/21060945/simple-way-to-copy-a-file-in-golang
 func copyFileContents(src, dst string) (err error) {
-	in, err := os.Open(src) // nolint gosec
+	in, err := os.Open(filepath.Clean(src)) // nolint gosec
 	if err != nil {
 		return err
 	}

--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -179,7 +179,10 @@ func NodeToString(node *CandidateNode) string {
 	if errorEncoding != nil {
 		log.Error("Error debugging node, %v", errorEncoding.Error())
 	}
-	encoder.Close()
+	errorClosingEncoder := encoder.Close()
+	if errorClosingEncoder != nil {
+		log.Error("Error closing encoder: ", errorClosingEncoder.Error())
+	}
 	tag := value.Tag
 	if value.Kind == yaml.DocumentNode {
 		tag = "doc"

--- a/pkg/yqlib/utils.go
+++ b/pkg/yqlib/utils.go
@@ -5,6 +5,8 @@ import (
 	"container/list"
 	"io"
 	"os"
+	"path/filepath"
+
 
 	yaml "gopkg.in/yaml.v3"
 )
@@ -13,7 +15,7 @@ func readStream(filename string) (io.Reader, error) {
 	if filename == "-" {
 		return bufio.NewReader(os.Stdin), nil
 	} else {
-		return os.Open(filename) // nolint gosec
+		return os.Open(filepath.Clean(filename)) // nolint gosec
 	}
 }
 

--- a/pkg/yqlib/utils.go
+++ b/pkg/yqlib/utils.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-
 	yaml "gopkg.in/yaml.v3"
 )
 

--- a/pkg/yqlib/write_in_place_handler.go
+++ b/pkg/yqlib/write_in_place_handler.go
@@ -54,6 +54,9 @@ func (w *writeInPlaceHandlerImpl) FinishWriteInPlace(evaluatedSuccessfully bool)
 		safelyRenameFile(w.tempFile.Name(), w.inputFilename)
 	} else {
 		log.Debug("removed temp file")
-		os.Remove(w.tempFile.Name())
+		removeErr := os.Remove(w.tempFile.Name())
+		if removeErr != nil {
+			log.Errorf("failed removing temp file: %s", w.tempFile.Name())
+		}
 	}
 }

--- a/test/utils.go
+++ b/test/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -81,7 +82,7 @@ func WriteTempYamlFile(content string) string {
 }
 
 func ReadTempYamlFile(name string) string {
-	content, _ := ioutil.ReadFile(name)
+	content, _ := ioutil.ReadFile(filepath.Clean(name))
 	return string(content)
 }
 


### PR DESCRIPTION
Hi there! I'm Monica, I work at [Bison Trails](https://bisontrails.co/). We're doing an internal hackathon this week.

My team loves yq, but it got flagged during a recent security review. We voted to use some hackathon time to try to get yq approved for usage within our organization again. 

### What's here:
- Use `filepath.Clean(name)` ([link](https://golang.org/pkg/path/filepath/#Clean)) instead of directly opening or reading a filepath in three places
- Handle an error closing the encoder or removing a temporary yaml file

### Impact: 
These changes should fix gosec warnings for rules G304 and G104. We identified these vulnerabilities using [Salus](https://github.com/coinbase/salus) and the [OSSF scorecard](https://github.com/ossf/scorecard). 
- [G304](https://cwe.mitre.org/data/definitions/22.html) - Potential file inclusion via variable
- [G104](https://cwe.mitre.org/data/definitions/703.html) - Errors unhandled

Thank you so much for your work maintaining yq, and thank you for taking the time to look at this PR!