### PR TITLE
Fix medium-severity finding for gosec rule G304

### DIFF
--- a/pkg/yqlib/file_utils.go
+++ b/pkg/yqlib/file_utils.go
@@ -3,6 +3,7 @@ package yqlib
 import (
 	"io"
 	"os"
+	"path/filepath"
 )
 
 func safelyRenameFile(from string, to string) {
@@ -25,7 +26,7 @@ func safelyRenameFile(from string, to string) {
 
 // thanks https://stackoverflow.com/questions/21060945/simple-way-to-copy-a-file-in-golang
 func copyFileContents(src, dst string) (err error) {
-	in, err := os.Open(src) // nolint gosec
+	in, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return err
 	}

--- a/pkg/yqlib/utils.go
+++ b/pkg/yqlib/utils.go
@@ -5,6 +5,7 @@ import (
 	"container/list"
 	"io"
 	"os"
+	"path/filepath"
 
 	yaml "gopkg.in/yaml.v3"
 )
@@ -13,7 +14,7 @@ func readStream(filename string) (io.Reader, error) {
 	if filename == "-" {
 		return bufio.NewReader(os.Stdin), nil
 	} else {
-		return os.Open(filename) // nolint gosec
+		return os.Open(filepath.Clean(filename))
 	}
 }
 

--- a/test/utils.go
+++ b/test/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -81,7 +82,7 @@ func WriteTempYamlFile(content string) string {
 }
 
 func ReadTempYamlFile(name string) string {
-	content, _ := ioutil.ReadFile(name)
+	content, _ := ioutil.ReadFile(filepath.Clean(name))
 	return string(content)
 }
 


### PR DESCRIPTION
Hi there! I'm Monica, I work at [Bison Trails](https://bisontrails.co/). We're doing an internal hackathon this week.

My team loves yq, but it got flagged during a recent security review. We voted to use some hackathon time to try to get yq approved for usage within our organization again. 

### What's here:
- Use `filepath.Clean(name)` ([link](https://golang.org/pkg/path/filepath/#Clean)) instead of directly opening or reading a filepath in three places

### Impact: 
These changes fix three gosec warnings for rule G304. We identified this finding using [Salus](https://github.com/coinbase/salus) and the [OSSF scorecard](https://github.com/ossf/scorecard). 
- [G304](https://cwe.mitre.org/data/definitions/22.html) - Potential file inclusion via variable

Thank you so much for your work maintaining yq, and thank you for taking the time to look at this PR.