### PR TITLE
setup golangci-lint-action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.15
+    - name: Set up Go 1.17
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.17
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Golangci-lint
+
+on: [push, pull_request]
+jobs:
+
+  golangci:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+run:
+  timeout: 5m
+linters:
+  enabled:
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,13 @@
 run:
   timeout: 5m
 linters:
-  enabled:
+  enable:
+    - gofmt
     - goimports
     - gosec
+issues:
+  exclude-rules:
+  - linters:
+    - gosec
+    text:  "Implicit memory aliasing in for loop."
+    path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,4 @@ run:
 linters:
   enabled:
     - goimports
+    - gosec


### PR DESCRIPTION
Hi !

Golangci-lint can be used directly as an action.
It allows you to see the warning and errors directly in the files of the PR.