### PR TITLE
lint : define golangci configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+    - gofmt
+    - goimports
+    - gosec
+issues:
+  exclude-rules:
+  - linters:
+    - gosec
+    text:  "Implicit memory aliasing in for loop."
+    path: _test\.go

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,8 +5,8 @@ set -o pipefail
 
 if command -v golangci-lint &> /dev/null
 then
-    golangci-lint run --timeout=5m
+    golangci-lint run --verbose
 else
-  ./bin/golangci-lint run --timeout=5m
+  ./bin/golangci-lint run --verbose
 fi
 


### PR DESCRIPTION
This put everything concerning golangci following [this](https://golangci-lint.run/usage/configuration/).
This way, anyone running golangci with a command line or with it's favorite Ide will use the same configuration for the current project.