### PR TITLE
simplify Dockerfile and docker portion of release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
-        
+
       - name: Generate man page
         uses: docker://pandoc/core:2.14.2
         id: gen-man-page
@@ -35,7 +35,7 @@ jobs:
             --variable=author:"Mike Farah"
             --output=yq.1
             ${{ steps.gen-man-page-md.outputs.man-page-md }}
-        
+
       - name: Cross compile
         run: |
           sudo apt-get install rhash -y
@@ -67,12 +67,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
-  
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -81,16 +81,29 @@ jobs:
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }} && docker version
- 
+
       - name: Build and push image
         run: |
           IMAGE_V_VERSION="$(git describe --tags --abbrev=0)"
           IMAGE_VERSION=${IMAGE_V_VERSION:1}
-
-          SHORT_SHA1=$(git rev-parse --short HEAD)
           PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64"
+
           echo "Building and pushing version ${IMAGE_VERSION} of image ${IMAGE_NAME}"
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-          docker buildx build --platform "${PLATFORMS}" -t "${IMAGE_NAME}:${IMAGE_VERSION}"  -t "${IMAGE_NAME}:latest" -t "${IMAGE_NAME}:4" \
-            --push .
-    
+          echo '${{ secrets.DOCKER_PASSWORD }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
+          docker buildx build \
+            --label "org.opencontainers.image.authors=https://github.com/mikefarah/yq/graphs/contributors" \
+            --label "org.opencontainers.image.created=$(date --rfc-3339=seconds)" \
+            --label "org.opencontainers.image.description=yq is a portable command-line YAML processor" \
+            --label "org.opencontainers.image.documentation=https://mikefarah.gitbook.io/yq/" \
+            --label "org.opencontainers.image.licenses=MIT" \
+            --label "org.opencontainers.image.revision=$(git rev-parse HEAD)" \
+            --label "org.opencontainers.image.source=https://github.com/mikefarah/yq" \
+            --label "org.opencontainers.image.title=yq" \
+            --label "org.opencontainers.image.url=https://mikefarah.gitbook.io/yq/" \
+            --label "org.opencontainers.image.version=${IMAGE_VERSION}" \
+            --platform "${PLATFORMS}" \
+            --push \
+            -t "${IMAGE_NAME}:${IMAGE_VERSION}" \
+            -t "${IMAGE_NAME}:4" \
+            -t "${IMAGE_NAME}:latest" \
+            .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.17 as builder
 
 WORKDIR /go/src/mikefarah/yq
 
-COPY . /go/src/mikefarah/yq
+COPY . .
 
 RUN CGO_ENABLED=0 go build .
 # RUN ./scripts/test.sh -- this too often times out in the github pipeline.
@@ -11,20 +11,15 @@ RUN ./scripts/acceptance.sh
 # Choose alpine as a base image to make this useful for CI, as many
 # CI tools expect an interactive shell inside the container
 FROM alpine:3 as production
-
-RUN mkdir /home/yq/
-RUN addgroup -g 1000 yq && \
-    adduser -u 1000 -G yq -s /bin/bash -h /home/yq -D yq
-RUN chown -R yq:yq /home/yq/
+LABEL maintainer="Mike Farah <mikefarah@users.noreply.github.com>"
 
 COPY --from=builder /go/src/mikefarah/yq/yq /usr/bin/yq
-RUN chmod +x /usr/bin/yq
-
-ARG VERSION=none
-LABEL version=${VERSION}
-
-USER yq
 
 WORKDIR /workdir
+
+RUN set -eux; \
+  addgroup -g 1000 yq; \
+  adduser -u 1000 -G yq -s /bin/sh -h /home/yq -D yq
+USER yq
 
 ENTRYPOINT ["/usr/bin/yq"]


### PR DESCRIPTION
This PR simplifies the second stage of the docker file to reduce the layer count a bit. We can eliminate some of these things that are redundant.

It also updates the action to add some of the standard labels which are documented at <https://github.com/opencontainers/image-spec/blob/main/annotations.md>

BTW the github actions `docker/metadata-action@v3`, and `docker/build-push-action@v2` can do most of this automatically.
