### PR TITLE
Include version query for tools

### DIFF
--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -ex
-go mod download golang.org/x/tools
+go mod download golang.org/x/tools@latest
 wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.37.1
 wget -O- -nv https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.9.1


### PR DESCRIPTION
I updated the command to include a version query. I was running into this error when running tests locally with `make test`:

`go: cannot match "golang.org/x/tools" without -versions or an explicit version: go.mod file not found in current directory or any parent directory; see 'go help modules'`
