### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,14 @@ linters:
     - revive
     - unconvert
     - unparam
+linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      - io/ioutil
+    packages-with-error-message:
+      - io/ioutil: "The 'io/ioutil' package is deprecated. Use corresponding 'os' or 'io' functions instead."
 issues:
   exclude-rules:
   - linters:

--- a/pkg/yqlib/file_utils.go
+++ b/pkg/yqlib/file_utils.go
@@ -3,7 +3,6 @@ package yqlib
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -77,7 +76,7 @@ func createTempFile() (*os.File, error) {
 		return nil, err
 	}
 
-	file, err := ioutil.TempFile("", "temp")
+	file, err := os.CreateTemp("", "temp")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/yqlib/front_matter_test.go
+++ b/pkg/yqlib/front_matter_test.go
@@ -1,7 +1,8 @@
 package yqlib
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/mikefarah/yq/v4/test"
@@ -24,7 +25,7 @@ func createTestFile(content string) string {
 }
 
 func readFile(filename string) string {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +61,7 @@ yaml: doc
 
 	test.AssertResult(t, expectedYamlFm, yamlFm)
 
-	contentBytes, err := ioutil.ReadAll(fmHandler.GetContentReader())
+	contentBytes, err := io.ReadAll(fmHandler.GetContentReader())
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +98,7 @@ yaml: doc
 
 	test.AssertResult(t, expectedYamlFm, yamlFm)
 
-	contentBytes, err := ioutil.ReadAll(fmHandler.GetContentReader())
+	contentBytes, err := io.ReadAll(fmHandler.GetContentReader())
 	if err != nil {
 		panic(err)
 	}
@@ -131,7 +132,7 @@ yaml: doc
 
 	test.AssertResult(t, expectedYamlFm, yamlFm)
 
-	contentBytes, err := ioutil.ReadAll(fmHandler.GetContentReader())
+	contentBytes, err := io.ReadAll(fmHandler.GetContentReader())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/yqlib/operator_load.go
+++ b/pkg/yqlib/operator_load.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"container/list"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -19,7 +18,7 @@ func loadString(filename string) (*CandidateNode, error) {
 	// ignore CWE-22 gosec issue - that's more targeted for http based apps that run in a public directory,
 	// and ensuring that it's not possible to give a path to a file outside that directory.
 
-	filebytes, err := ioutil.ReadFile(filename) // #nosec
+	filebytes, err := os.ReadFile(filename) // #nosec
 	if err != nil {
 		return nil, err
 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ apps:
 parts:
   yq:
     plugin: go
-    go-channel: 1.15/stable
+    go-channel: 1.17/stable
     source: .
     source-type: git
     go-importpath: github.com/mikefarah/yq


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

This PR also bumps the `go-channel` in `snapcraft.yml` to `1.17/stable`.