### PR TITLE
fixes path in scripts/generate-man-page-md.sh

### DIFF
--- a/scripts/generate-man-page-md.sh
+++ b/scripts/generate-man-page-md.sh
@@ -3,10 +3,10 @@ set -e
 
 # note that this reqires pandoc to be installed.
 
-cat ./pkg/yqlib/doc/headers/Main.md > man.md
+cat ./pkg/yqlib/doc/operators/headers/Main.md > man.md
 printf "\n# HOW IT WORKS\n" >> man.md
 tail -n +2 how-it-works.md >> man.md
 
-for f in ./pkg/yqlib/doc/*.md; do 
+for f in ./pkg/yqlib/doc/*.md; do
   cat "$f" >> man.md
 done


### PR DESCRIPTION
I noticed that `./pkg/yqlib/doc/headers/Main.md` is no longer a valid path, appears to be missing operators in path.

This PR should fix that 😃 

Awesome project BTW