### PR TITLE
Fix zsh completion

### DIFF
--- a/acceptance_tests/completion.sh
+++ b/acceptance_tests/completion.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+testCompletionRuns() {
+    result=$(./yq __complete "" 2>&1)
+    assertEquals 0 $?
+    assertContains "$result" "Completion ended with directive:"
+}
+
+source ./scripts/shunit2

--- a/yq.go
+++ b/yq.go
@@ -12,7 +12,7 @@ func main() {
 	args := os.Args[1:]
 
 	_, _, err := cmd.Find(args)
-	if err != nil {
+	if err != nil && args[0] != "__complete" {
 		// default command when nothing matches...
 		newArgs := []string{"eval"}
 		cmd.SetArgs(append(newArgs, os.Args[1:]...))


### PR DESCRIPTION
4ec533b introduced a bug which causes the 'hidden' cli parameter `__complete` to be ignored.

Add a check for this parameter, so that it can be correctly passed to `cobra`

There is still an issue - `yq <tab>` will suggest that a subcommand is run, not a file. I think 'pick eval by default' could be done in a more cobra-friendly way, but I just don't know enough about it to implement that