### PR TITLE
handle `EvaluateNodes` nil panic

### DIFF
--- a/pkg/yqlib/all_at_once_evaluator.go
+++ b/pkg/yqlib/all_at_once_evaluator.go
@@ -22,6 +22,7 @@ type allAtOnceEvaluator struct {
 }
 
 func NewAllAtOnceEvaluator() Evaluator {
+	InitExpressionParser()
 	return &allAtOnceEvaluator{treeNavigator: NewDataTreeNavigator()}
 }
 

--- a/pkg/yqlib/all_at_once_evaluator_test.go
+++ b/pkg/yqlib/all_at_once_evaluator_test.go
@@ -31,7 +31,6 @@ var evaluateNodesScenario = []expressionScenario{
 }
 
 func TestAllAtOnceEvaluateNodes(t *testing.T) {
-	InitExpressionParser()
 	var evaluator = NewAllAtOnceEvaluator()
 	for _, tt := range evaluateNodesScenario {
 		node := test.ParseData(tt.document)

--- a/pkg/yqlib/expression_parser_test.go
+++ b/pkg/yqlib/expression_parser_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func getExpressionParser() ExpressionParserInterface {
-	if ExpressionParser == nil {
-		ExpressionParser = newExpressionParser()
-	}
+	InitExpressionParser()
 	return ExpressionParser
 }
 


### PR DESCRIPTION
`EvaluateNodes` currently panics on a nil pointer here:
https://github.com/mikefarah/yq/blob/535799462f14cdb1c25e09f57381f86d8b95db66/pkg/yqlib/all_at_once_evaluator.go#L37

Fix for this is either:
*  checking for nil in `EvaluateCandidateNodes` 
*  calling `InitExpressionParser()` inside of `NewAllAtOnceEvaluator` (in this PR). 

Either approach is better than the current yqlib `NewAllAtOnceEvaluator` that leads to a footgun.