### PR TITLE
update cli help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,10 @@ See https://mikefarah.gitbook.io/yq/ for detailed documentation and examples.`,
 cat myfile.yml | yq '.stuff' 
 
 # update myfile.yml in place
-yq -i '.stuff = "foo"' myfile.yml # update myfile.yml inplace
+yq -i '.stuff = "foo"' myfile.yml
+
+# print contents of sample.json as idiomatic YAML
+yq -P '.' sample.json
 `,
 
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Hi! json -> (idiomatic) yml conversion is the main (only) reason I installed yq but I tend to forget the syntax. I created a "json2yml" alias for myself but I thought this updated `--help` might be useful to new users. While the `--input-format` flag states "Note that json is a subset of yaml," (and I feel a little dumb admitting it) it was non-obvious to me that this meant no `--input-format` is required to parse json.

- remove duplicate comment
- add common use case (json -> idiomatic yml)