### PR TITLE
chore: Add docs for creating YAML with multiple objects

### DIFF
--- a/pkg/yqlib/doc/operators/create-collect-into-object.md
+++ b/pkg/yqlib/doc/operators/create-collect-into-object.md
@@ -86,3 +86,16 @@ will output
 wrap: frog
 ```
 
+## Creating yaml from scratch with multiple objects
+Running
+```bash
+yq --null-input '(.a.b = "foo") | (.d.e = "bar")'
+```
+will output
+```yaml
+a:
+  b: foo
+d:
+  e: bar
+```
+


### PR DESCRIPTION
Thanks for developing such a wonderful plugin and maintaining it. I know its not so easy to update docs with all the possible examples but I found it really difficult to figure out the syntax for creating a YAML file with multiple objects.

May be it is a straight forward one for someone who is familiar with `yq` but for a new learner like me, It took a lot of time. I finally found the solution in one of the issue comments and I thought I create a Pull Request. 