### PR TITLE
Fix panic when multiply assign

### DIFF
--- a/pkg/yqlib/operator_assign.go
+++ b/pkg/yqlib/operator_assign.go
@@ -22,8 +22,8 @@ func assignUpdateOperator(d *dataTreeNavigator, context Context, expressionNode 
 	}
 
 	prefs := assignPreferences{}
-	if expressionNode.Operation.Preferences != nil {
-		prefs = expressionNode.Operation.Preferences.(assignPreferences)
+	if p, ok := expressionNode.Operation.Preferences.(assignPreferences); ok {
+		prefs = p
 	}
 
 	if !expressionNode.Operation.UpdateAssign {

--- a/pkg/yqlib/operator_multiply.go
+++ b/pkg/yqlib/operator_multiply.go
@@ -27,7 +27,6 @@ func createMultiplyOp(prefs interface{}) func(lhs *ExpressionNode, rhs *Expressi
 
 func multiplyAssignOperator(d *dataTreeNavigator, context Context, expressionNode *ExpressionNode) (Context, error) {
 	var multiplyPrefs = expressionNode.Operation.Preferences
-	expressionNode.Operation.Preferences = nil
 
 	return compoundAssignFunction(d, context, expressionNode, createMultiplyOp(multiplyPrefs))
 }


### PR DESCRIPTION
I fix https://github.com/mikefarah/yq/issues/1256

When multi documents exist, I've got panic because of `expressionNode.Operation.Preferences = nil`.
But I've got type assertion error instead of this issue when I remove it. So I make type assertion safe.
