### PR TITLE
Fix flag

### DIFF
--- a/usage/csv-tsv.md
+++ b/usage/csv-tsv.md
@@ -10,8 +10,8 @@ Note that versions prior to 4.18 require the 'eval/e' command to be specified.&#
 
 You can convert compatible yaml structures to CSV or TSV by using:
 
-* `--outputformat=csv` or `-o=c` for csv (comma separated values)
-* `--outputformat=tsv` or `-o=t` for tsv (tab separated values)
+* `--output-format=csv` or `-o=c` for csv (comma separated values)
+* `--output-format=tsv` or `-o=t` for tsv (tab separated values)
 
 Compatible structures is either an array of scalars (strings/numbers/booleans), which is a single row; or an array of arrays of scalars (multiple rows).
 


### PR DESCRIPTION
Hi @mikefarah , thanks for yq!

I wanted to fix the flag here, since it seems that the correct flag should be `--output-format` instead of `--outputformat` on [the Working with CSV, TSV page](https://mikefarah.gitbook.io/yq/usage/csv-tsv)