### PR TITLE
add build argument to use different uid/gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN ./scripts/acceptance.sh
 # Choose alpine as a base image to make this useful for CI, as many
 # CI tools expect an interactive shell inside the container
 FROM alpine:3 as production
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
 LABEL maintainer="Mike Farah <mikefarah@users.noreply.github.com>"
 
 COPY --from=builder /go/src/mikefarah/yq/yq /usr/bin/yq
@@ -18,8 +21,8 @@ COPY --from=builder /go/src/mikefarah/yq/yq /usr/bin/yq
 WORKDIR /workdir
 
 RUN set -eux; \
-  addgroup -g 1000 yq; \
-  adduser -u 1000 -G yq -s /bin/sh -h /home/yq -D yq
+  addgroup -g $GROUP_ID yq; \
+  adduser -u $USER_ID -G yq -s /bin/sh -h /home/yq -D yq
 
 RUN chown -R yq:yq /workdir
 


### PR DESCRIPTION
While uid/gid 1000 will work in most setups, sometimes users have
different uid/gid. For example is a shared machine with multiple
users.
