### PR TITLE
Document dynamic get and output in GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ If you are using podman with SELinux, you will need to set the shared volume fla
     uses: mikefarah/yq@master
     with:
       cmd: yq -i '.foo.bar = "cool"' 'config.yml'
+  - name: Get an entry with a variable that might contain dots or spaces
+    id: get_username
+    uses: mikefarah/yq@master
+    with:
+      cmd: yq '.all.children.["${{ matrix.ip_address }}"].username' ops/inventories/production.yml
+  - name: Reuse a variable obtained in another step
+    run: echo ${{ steps.get_username.outputs.result }}
 ```
 
 See https://mikefarah.gitbook.io/yq/usage/github-action for more.


### PR DESCRIPTION
Thanks for `yq` and its GitHub Action integration!

I encountered a not-so-easy limitation: GitHub Actions escape and interpolate rules can conflict with some yq syntax. In particular, it took me some time to figure out how to quote a variable that could contain dots in a query path (more usage context: https://github.com/ambanum/OpenTermsArchive/pull/899).

This changeset adds such an example to the README. I wasn't sure if you'd prefer to have it there or in the `gitbook` branch so I went for the easiest :wink: