### PR TITLE
Removing USER directive from the github action Dockerfile

### DIFF
--- a/github-action/Dockerfile
+++ b/github-action/Dockerfile
@@ -2,7 +2,4 @@ FROM mikefarah/yq:4
 
 COPY entrypoint.sh /entrypoint.sh
 
-# this seems to be the default user in github actions
-USER 1001
-
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The problem that this tries to solve is enabling in-place editing of yaml files that are the result of the checkout github action. The files are checkout in the GITHUB_WORKSPACE directory by the runner user.

As mentioned here - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#docker-container-filesystem we should omit the USER directive from the Dockerfile. 

The problem is twofold: 
- the runner user is with uid 1000 and here we set the USER to 1001
- the documentation mentions to not set the USER for the github action container.

In the main yq container we already set the USER to yq which has uid 1000, which currently matches the runner user uid. So this will kind of work as it is but only if we do not set the USER to 1001 in the github-action/Dockerfile.