### PR TITLE
Fix set-output deprecate; keys are case sensitive

### DIFF
--- a/github-action/entrypoint.sh
+++ b/github-action/entrypoint.sh
@@ -8,4 +8,4 @@ RESULT="${RESULT//$'\r'/'%0D'}"
 echo "::debug::\$RESULT: $RESULT"
 # updating from 
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-echo "RESULT=$RESULT" >> $GITHUB_OUTPUT
+echo "result=$RESULT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
One line fix to resolve #1382 for https://github.com/guihkx and other currently broken downstream workflows.

@MattiSG @mikefarah 