### PR TITLE
Fix set-output deprecate; multiline was broken

### DIFF
--- a/github-action/entrypoint.sh
+++ b/github-action/entrypoint.sh
@@ -2,10 +2,11 @@
 set -e
 echo "::debug::\$cmd: $1"
 RESULT=$(eval "$1")
-RESULT="${RESULT//'%'/'%25'}"
-RESULT="${RESULT//$'\n'/'%0A'}"
-RESULT="${RESULT//$'\r'/'%0D'}"
 echo "::debug::\$RESULT: $RESULT"
 # updating from 
+# https://github.com/orgs/community/discussions/26288#discussioncomment-3876281
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-echo "result=$RESULT" >> $GITHUB_OUTPUT
+delimiter=$(cat /proc/sys/kernel/random/uuid)
+echo "result<<${delimiter}" >> "${GITHUB_OUTPUT}"
+echo "${RESULT}" >> "${GITHUB_OUTPUT}"
+echo "${delimiter}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This is a followup to #1383 and closes the loop on set-output deprecation issues our team was still having using master yq. 

We were using yq for merging base values with env specific values in Helm. This commit has been tested on our end and fixes multiline usage of yq by the following:

1. Remove escaping of special characters
    -  Otherwise you'll encounter breaking changes for example `appVersion: "1.0.0"%0Aapplica...` where `%0A` is escaped newline `\n` but shouldn't be escaped.
    -  Read more here: https://github.com/orgs/community/discussions/26288#discussioncomment-3876281

2. Delimiter is required for multiline strings
    -  https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
    -  Delimeter must be random. UUID is a solid choice. I verified that `/proc/sys/kernel/random/uuid` does indeed exist on the yq image.

@mikefarah @MattiSG 

----

### Example of broken workflows before:
<img width="682" alt="Screen Shot 2022-10-18 at 4 55 18 PM" src="https://user-images.githubusercontent.com/79610204/196552357-6cf62d3c-3644-4d71-9b23-026920b84070.png">

### After:
<img width="682" alt="Screen Shot 2022-10-18 at 4 56 12 PM" src="https://user-images.githubusercontent.com/79610204/196552455-f36fb73d-03ef-45dc-9ca5-9adb7039d149.png">
