### PR TITLE
fix lib.go unhandled error

### DIFF
--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -263,6 +263,9 @@ func parseSnippet(value string) (*yaml.Node, error) {
 		return nil, err
 	}
 	parsedNode, err := decoder.Decode()
+	if err != nil {
+		return nil, err
+	}
 	if len(parsedNode.Node.Content) == 0 {
 		return nil, fmt.Errorf("bad data")
 	}


### PR DESCRIPTION
Unfortunately, I can't find a way to reproduce this bug with a minimal csv file.

When I try to convert a CSV file to JSON.
The `err` returned from `decoder.Decode()` method is: `"yaml: found character that cannot start any token"`.
And this makes `parsedNode` `nil`, and `parsedNode.Node` will panic.

So I added a line to check the returned `err` from `Decode()` method.