### PR TITLE
Improve release-deb.sh

### DIFF
--- a/.github/workflows/test-deb.yml
+++ b/.github/workflows/test-deb.yml
@@ -1,0 +1,27 @@
+name: Test release-deb.sh
+on: 
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        platform: [ x86_64, aarch64]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y qemu-user-static binfmt-support
+          scripts/release-deb.sh 999 --platform ${{ matrix.platform }}

--- a/scripts/release-deb.sh
+++ b/scripts/release-deb.sh
@@ -131,7 +131,7 @@ cat << EOF > ${blddir}/build.sh
 #!/bin/bash 
 set -e -o pipefail
 
-PATH=$PATH:/usr/local/go/bin
+PATH=\$PATH:/usr/local/go/bin
 export GPG_TTY=$(tty)
 
 go mod vendor

--- a/scripts/release-deb.sh
+++ b/scripts/release-deb.sh
@@ -157,7 +157,7 @@ fi
 gbp dch --ignore-branch --no-multimaint -N "$VERSION" -s "\$SINCE" -D "\$DISTRIBUTION"
 
 # using -d to prevent failing when searching for golang dep on control file
-params=("-d" "-S")
+params=("-d")
 
 # add the -sa option for signing along with the key to use when provided key id
 if [ -n "$DO_SIGN" ]; then


### PR DESCRIPTION
* Enable binary package build in addition to source package (both will be generated)
* Fix a bug in the `build.sh` where host $PATH overwrites docker $PATH and could break build (for example when running from Arch host)
* Fix build when host user does not have UID 1000 (for example GitHub runner's UID is 1001)
* Allow cross build for other architecture with `--platform` flag (currently support `x86_64` and `aarch64` only)
* Also add CI script to test this code in every push

Our company builds custom Debian images for our hardware products. As such we prefer to have a proper deb distributed via our apt repo, instead of wgetting a random binary from GitHub release page. We also build all our packages with GitHub workflows, and they have to run on ARM64 machines, so this PR added those capabilities.

Since `yq` is an important dependency for us, we also added a basic CI workflow to make sure the packaging script will not go bad without being noticed.