### PR TITLE
Use a lazy-quoting @sh encoder

### DIFF
--- a/pkg/yqlib/doc/operators/encode-decode.md
+++ b/pkg/yqlib/doc/operators/encode-decode.md
@@ -478,7 +478,7 @@ yq '.coolData | @sh' sample.yml
 ```
 will output
 ```yaml
-'strings with spaces and a \'quote\''
+strings' with spaces and a '\'quote\'
 ```
 
 ## Decode a base64 encoded string

--- a/pkg/yqlib/operator_encoder_decoder_test.go
+++ b/pkg/yqlib/operator_encoder_decoder_test.go
@@ -267,6 +267,16 @@ var encoderDecoderOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
+		description:    "Encode a string to sh",
+		subdescription: "Watch out for stray '' (empty strings)",
+		document:       "coolData: \"'starts, contains more '' and ends with a quote'\"",
+		expression:     ".coolData | @sh",
+		expected: []string{
+			"D0, P[coolData], (!!str)::\\'starts,' contains more '\\'\\'' and ends with a quote'\\'\n",
+		},
+		skipDoc: true,
+	},
+	{
 		description:    "Decode a base64 encoded string",
 		subdescription: "Decoded data is assumed to be a string.",
 		document:       "coolData: V29ya3Mgd2l0aCBVVEYtMTYg8J+Yig==",

--- a/pkg/yqlib/operator_encoder_decoder_test.go
+++ b/pkg/yqlib/operator_encoder_decoder_test.go
@@ -263,7 +263,7 @@ var encoderDecoderOperatorScenarios = []expressionScenario{
 		document:       "coolData: strings with spaces and a 'quote'",
 		expression:     ".coolData | @sh",
 		expected: []string{
-			"D0, P[coolData], (!!str)::'strings with spaces and a \\'quote\\''\n",
+			"D0, P[coolData], (!!str)::strings' with spaces and a '\\'quote\\'\n",
 		},
 	},
 	{


### PR DESCRIPTION
I eventually took a hit at the second alternative from https://github.com/mikefarah/yq/issues/1526#issuecomment-1413650693, which is generally ouptut-size optimal and behaves nice for strings with a lot of safe characters.