### PR TITLE
Minor typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Development
 
-1. Install (golang)[https://golang.org/]
+1. Install (Golang)[https://golang.org/]
 1. Run  `scripts/devtools.sh` to install the required devtools
 2. Run `make [local] vendor` to install the vendor dependencies
 2. Run `make [local] test` to ensure you can run the existing tests

--- a/debian/changelog
+++ b/debian/changelog
@@ -103,7 +103,7 @@ yq (4.16.2) focal; urgency=medium
   * Improved extract-checksum.sh
   * Bump github.com/spf13/cobra from 1.2.1 to 1.3.0 (#1039)
   * enable more linters (#1043)
-  * Bump golang compiler #1037
+  * Bump Golang compiler #1037
 
  -- Roberto Mier Escandon <rmescandon@gmail.com>  Tue, 21 Dec 2021 09:41:44 +0000
 

--- a/pkg/yqlib/doc/operators/anchor-and-alias-operators.md
+++ b/pkg/yqlib/doc/operators/anchor-and-alias-operators.md
@@ -302,7 +302,7 @@ foobar:
 ```
 
 ## Dereference and update a field
-`Use explode with multiply to dereference an object
+Use explode with multiply to dereference an object
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/doc/operators/assign-update.md
+++ b/pkg/yqlib/doc/operators/assign-update.md
@@ -250,7 +250,7 @@ a: !cat woof
 b: !dog woof
 ```
 
-## Custom types: clovver
+## Custom types: clobber
 Use the `c` option to clobber custom tags
 
 Given a sample.yml file of:

--- a/pkg/yqlib/doc/operators/assign-update.md
+++ b/pkg/yqlib/doc/operators/assign-update.md
@@ -3,7 +3,7 @@
 This operator is used to update node values. It can be used in either the:
 
 ### plain form: `=`
-Which will assign the LHS node values to the RHS node values. The RHS expression is run against the matching nodes in the pipeline.
+Which will set the LHS node values equal to the RHS node values. The RHS expression is run against the matching nodes in the pipeline.
 
 ### relative form: `|=`
 This will do a similar thing to the plain form, however, the RHS expression is run against _the LHS nodes_. This is useful for updating values based on old values, e.g. increment.

--- a/pkg/yqlib/doc/operators/assign-update.md
+++ b/pkg/yqlib/doc/operators/assign-update.md
@@ -6,7 +6,7 @@ This operator is used to update node values. It can be used in either the:
 Which will set the LHS node values equal to the RHS node values. The RHS expression is run against the matching nodes in the pipeline.
 
 ### relative form: `|=`
-This will do a similar thing to the plain form, however, the RHS expression is run against _the LHS nodes_. This is useful for updating values based on old values, e.g. increment.
+This will do a similar thing to the plain form, but the RHS expression is run with _each LHS node as context_. This is useful for updating values based on old values, e.g. increment.
 
 
 ### Flags

--- a/pkg/yqlib/doc/operators/assign-update.md
+++ b/pkg/yqlib/doc/operators/assign-update.md
@@ -203,7 +203,7 @@ a:
 ```
 
 ## Update node value that has an anchor
-Anchor will remaple
+Anchor will remain
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/doc/operators/comment-operators.md
+++ b/pkg/yqlib/doc/operators/comment-operators.md
@@ -5,7 +5,7 @@ Use these comment operators to set or retrieve comments. Note that line comments
 Like the `=` and `|=` assign operators, the same syntax applies when updating comments:
 
 ### plain form: `=`
-This will assign the LHS nodes comments to the expression on the RHS. The RHS is run against the matching nodes in the pipeline
+This will set the LHS nodes' comments equal to the expression on the RHS. The RHS is run against the matching nodes in the pipeline
 
 ### relative form: `|=` 
 Similar to the plain form, however the RHS evaluates against each matching LHS node! This is useful if you want to set the comments as a relative expression of the node, for instance its value or path.

--- a/pkg/yqlib/doc/operators/comment-operators.md
+++ b/pkg/yqlib/doc/operators/comment-operators.md
@@ -8,7 +8,7 @@ Like the `=` and `|=` assign operators, the same syntax applies when updating co
 This will set the LHS nodes' comments equal to the expression on the RHS. The RHS is run against the matching nodes in the pipeline
 
 ### relative form: `|=` 
-Similar to the plain form, however the RHS evaluates against each matching LHS node! This is useful if you want to set the comments as a relative expression of the node, for instance its value or path.
+This is similar to the plain form, but it evaluates the RHS with _each matching LHS node as context_. This is useful if you want to set the comments as a relative expression of the node, for instance its value or path.
 
 ## Set line comment
 Set the comment on the key node for more reliability (see below).

--- a/pkg/yqlib/doc/operators/contains.md
+++ b/pkg/yqlib/doc/operators/contains.md
@@ -4,7 +4,7 @@ This returns `true` if the context contains the passed in parameter, and false o
 
 {% hint style="warning" %}
 
-_Note_ that, just like jq, when checking if an array of strings `contains` another, this will use `contains` and _not_ equals to check each string. This means an array like `contains(["cat"])` will return true for an array `["cats"]`.
+_Note_ that, just like jq, when checking if an array of strings `contains` another, this will use `contains` and _not_ equals to check each string. This means an expression like `contains(["cat"])` will return true for an array `["cats"]`.
 
 See the "Array has a subset array" example below on how to check for a subset.
 

--- a/pkg/yqlib/doc/operators/datetime.md
+++ b/pkg/yqlib/doc/operators/datetime.md
@@ -17,11 +17,11 @@ See the [library docs](https://pkg.go.dev/time#pkg-constants) for examples of fo
 
 
 ## Timezones
-This uses golangs built in LoadLocation function to parse timezones strings. See the [library docs](https://pkg.go.dev/time#LoadLocation) for more details.
+This uses Golang's built in LoadLocation function to parse timezones strings. See the [library docs](https://pkg.go.dev/time#LoadLocation) for more details.
 
 
 ## Durations
-Durations are parsed using golangs built in [ParseDuration](https://pkg.go.dev/time#ParseDuration) function.
+Durations are parsed using Golang's built in [ParseDuration](https://pkg.go.dev/time#ParseDuration) function.
 
 You can durations to time using the `+` operator.
 

--- a/pkg/yqlib/doc/operators/datetime.md
+++ b/pkg/yqlib/doc/operators/datetime.md
@@ -3,7 +3,7 @@
 Various operators for parsing and manipulating dates. 
 
 ## Date time formattings
-This uses the golangs built in time library for parsing and formatting date times.
+This uses Golang's built in time library for parsing and formatting date times.
 
 When not specified, the RFC3339 standard is assumed `2006-01-02T15:04:05Z07:00` for parsing.
 

--- a/pkg/yqlib/doc/operators/datetime.md
+++ b/pkg/yqlib/doc/operators/datetime.md
@@ -23,7 +23,7 @@ This uses Golang's built in LoadLocation function to parse timezones strings. Se
 ## Durations
 Durations are parsed using Golang's built in [ParseDuration](https://pkg.go.dev/time#ParseDuration) function.
 
-You can durations to time using the `+` operator.
+You can add durations to time using the `+` operator.
 
 ## Format: from standard RFC3339 format
 Providing a single parameter assumes a standard RFC3339 datetime format. If the target format is not a valid yaml datetime format, the result will be a string tagged node.

--- a/pkg/yqlib/doc/operators/encode-decode.md
+++ b/pkg/yqlib/doc/operators/encode-decode.md
@@ -309,7 +309,7 @@ cat,"thing1,thing2",true,3.40
 dog,thing3,false,12
 ```
 
-## Encode array of array scalars as tsv string
+## Encode array of arrays as tsv string
 Scalars are strings, numbers and booleans.
 
 Given a sample.yml file of:

--- a/pkg/yqlib/doc/operators/entries.md
+++ b/pkg/yqlib/doc/operators/entries.md
@@ -67,7 +67,8 @@ a: 1
 b: 2
 ```
 
-## from_entries with numeric key indexes
+## from_entries with numeric key indices
+
 from_entries always creates a map, even for numeric keys
 
 Given a sample.yml file of:

--- a/pkg/yqlib/doc/operators/eval.md
+++ b/pkg/yqlib/doc/operators/eval.md
@@ -4,7 +4,7 @@ Use `eval` to dynamically process an expression - for instance from an environme
 
 `eval` takes a single argument, and evaluates that as a `yq` expression. Any valid expression can be used, be it a path `.a.b.c | select(. == "cat")`, or an update `.a.b.c = "gogo"`.
 
-Tip: This can be useful way parameterise complex scripts.
+Tip: This can be a useful way to parameterise complex scripts.
 
 ## Dynamically evaluate a path
 Given a sample.yml file of:

--- a/pkg/yqlib/doc/operators/eval.md
+++ b/pkg/yqlib/doc/operators/eval.md
@@ -2,7 +2,7 @@
 
 Use `eval` to dynamically process an expression - for instance from an environment variable.
 
-`eval` takes a single argument, and evaluates that as a `yq` expression. Any valid expression can be used, beit a path `.a.b.c | select(. == "cat")`, or an update `.a.b.c = "gogo"`.
+`eval` takes a single argument, and evaluates that as a `yq` expression. Any valid expression can be used, be it a path `.a.b.c | select(. == "cat")`, or an update `.a.b.c = "gogo"`.
 
 Tip: This can be useful way parameterise complex scripts.
 

--- a/pkg/yqlib/doc/operators/has.md
+++ b/pkg/yqlib/doc/operators/has.md
@@ -1,6 +1,6 @@
 # Has
 
-This is operation that returns true if the key exists in a map (or index in an array), false otherwise.
+This operation returns true if the key exists in a map (or index in an array), false otherwise.
 
 ## Has map key
 Given a sample.yml file of:

--- a/pkg/yqlib/doc/operators/headers/assign-update.md
+++ b/pkg/yqlib/doc/operators/headers/assign-update.md
@@ -3,7 +3,7 @@
 This operator is used to update node values. It can be used in either the:
 
 ### plain form: `=`
-Which will assign the LHS node values to the RHS node values. The RHS expression is run against the matching nodes in the pipeline.
+Which will set the LHS node values equal to the RHS node values. The RHS expression is run against the matching nodes in the pipeline.
 
 ### relative form: `|=`
 This will do a similar thing to the plain form, however, the RHS expression is run against _the LHS nodes_. This is useful for updating values based on old values, e.g. increment.

--- a/pkg/yqlib/doc/operators/headers/assign-update.md
+++ b/pkg/yqlib/doc/operators/headers/assign-update.md
@@ -6,7 +6,7 @@ This operator is used to update node values. It can be used in either the:
 Which will set the LHS node values equal to the RHS node values. The RHS expression is run against the matching nodes in the pipeline.
 
 ### relative form: `|=`
-This will do a similar thing to the plain form, however, the RHS expression is run against _the LHS nodes_. This is useful for updating values based on old values, e.g. increment.
+This will do a similar thing to the plain form, but the RHS expression is run with _each LHS node as context_. This is useful for updating values based on old values, e.g. increment.
 
 
 ### Flags

--- a/pkg/yqlib/doc/operators/headers/comment-operators.md
+++ b/pkg/yqlib/doc/operators/headers/comment-operators.md
@@ -5,7 +5,7 @@ Use these comment operators to set or retrieve comments. Note that line comments
 Like the `=` and `|=` assign operators, the same syntax applies when updating comments:
 
 ### plain form: `=`
-This will assign the LHS nodes comments to the expression on the RHS. The RHS is run against the matching nodes in the pipeline
+This will set the LHS nodes' comments equal to the expression on the RHS. The RHS is run against the matching nodes in the pipeline
 
 ### relative form: `|=` 
 Similar to the plain form, however the RHS evaluates against each matching LHS node! This is useful if you want to set the comments as a relative expression of the node, for instance its value or path.

--- a/pkg/yqlib/doc/operators/headers/comment-operators.md
+++ b/pkg/yqlib/doc/operators/headers/comment-operators.md
@@ -8,4 +8,4 @@ Like the `=` and `|=` assign operators, the same syntax applies when updating co
 This will set the LHS nodes' comments equal to the expression on the RHS. The RHS is run against the matching nodes in the pipeline
 
 ### relative form: `|=` 
-Similar to the plain form, however the RHS evaluates against each matching LHS node! This is useful if you want to set the comments as a relative expression of the node, for instance its value or path.
+This is similar to the plain form, but it evaluates the RHS with _each matching LHS node as context_. This is useful if you want to set the comments as a relative expression of the node, for instance its value or path.

--- a/pkg/yqlib/doc/operators/headers/contains.md
+++ b/pkg/yqlib/doc/operators/headers/contains.md
@@ -4,7 +4,7 @@ This returns `true` if the context contains the passed in parameter, and false o
 
 {% hint style="warning" %}
 
-_Note_ that, just like jq, when checking if an array of strings `contains` another, this will use `contains` and _not_ equals to check each string. This means an array like `contains(["cat"])` will return true for an array `["cats"]`.
+_Note_ that, just like jq, when checking if an array of strings `contains` another, this will use `contains` and _not_ equals to check each string. This means an expression like `contains(["cat"])` will return true for an array `["cats"]`.
 
 See the "Array has a subset array" example below on how to check for a subset.
 

--- a/pkg/yqlib/doc/operators/headers/datetime.md
+++ b/pkg/yqlib/doc/operators/headers/datetime.md
@@ -23,4 +23,4 @@ This uses Golang's built in LoadLocation function to parse timezones strings. Se
 ## Durations
 Durations are parsed using Golang's built in [ParseDuration](https://pkg.go.dev/time#ParseDuration) function.
 
-You can durations to time using the `+` operator.
+You can add durations to time using the `+` operator.

--- a/pkg/yqlib/doc/operators/headers/datetime.md
+++ b/pkg/yqlib/doc/operators/headers/datetime.md
@@ -3,7 +3,7 @@
 Various operators for parsing and manipulating dates. 
 
 ## Date time formattings
-This uses the golangs built in time library for parsing and formatting date times.
+This uses Golang's built in time library for parsing and formatting date times.
 
 When not specified, the RFC3339 standard is assumed `2006-01-02T15:04:05Z07:00` for parsing.
 

--- a/pkg/yqlib/doc/operators/headers/datetime.md
+++ b/pkg/yqlib/doc/operators/headers/datetime.md
@@ -17,10 +17,10 @@ See the [library docs](https://pkg.go.dev/time#pkg-constants) for examples of fo
 
 
 ## Timezones
-This uses golangs built in LoadLocation function to parse timezones strings. See the [library docs](https://pkg.go.dev/time#LoadLocation) for more details.
+This uses Golang's built in LoadLocation function to parse timezones strings. See the [library docs](https://pkg.go.dev/time#LoadLocation) for more details.
 
 
 ## Durations
-Durations are parsed using golangs built in [ParseDuration](https://pkg.go.dev/time#ParseDuration) function.
+Durations are parsed using Golang's built in [ParseDuration](https://pkg.go.dev/time#ParseDuration) function.
 
 You can durations to time using the `+` operator.

--- a/pkg/yqlib/doc/operators/headers/eval.md
+++ b/pkg/yqlib/doc/operators/headers/eval.md
@@ -2,6 +2,6 @@
 
 Use `eval` to dynamically process an expression - for instance from an environment variable.
 
-`eval` takes a single argument, and evaluates that as a `yq` expression. Any valid expression can be used, beit a path `.a.b.c | select(. == "cat")`, or an update `.a.b.c = "gogo"`.
+`eval` takes a single argument, and evaluates that as a `yq` expression. Any valid expression can be used, be it a path `.a.b.c | select(. == "cat")`, or an update `.a.b.c = "gogo"`.
 
 Tip: This can be useful way parameterise complex scripts.

--- a/pkg/yqlib/doc/operators/headers/eval.md
+++ b/pkg/yqlib/doc/operators/headers/eval.md
@@ -4,4 +4,4 @@ Use `eval` to dynamically process an expression - for instance from an environme
 
 `eval` takes a single argument, and evaluates that as a `yq` expression. Any valid expression can be used, be it a path `.a.b.c | select(. == "cat")`, or an update `.a.b.c = "gogo"`.
 
-Tip: This can be useful way parameterise complex scripts.
+Tip: This can be a useful way to parameterise complex scripts.

--- a/pkg/yqlib/doc/operators/headers/has.md
+++ b/pkg/yqlib/doc/operators/headers/has.md
@@ -1,3 +1,3 @@
 # Has
 
-This is operation that returns true if the key exists in a map (or index in an array), false otherwise.
+This operation returns true if the key exists in a map (or index in an array), false otherwise.

--- a/pkg/yqlib/doc/operators/headers/recursive-descent-glob.md
+++ b/pkg/yqlib/doc/operators/headers/recursive-descent-glob.md
@@ -12,7 +12,7 @@ yq '.. style= "flow"' file.yaml
 ```
 
 ## match values and map keys form `...`
-The also includes map keys in the results set. This is particularly useful in YAML as unlike JSON, map keys can have their own styling, tags and use anchors and aliases.
+The also includes map keys in the results set. This is particularly useful in YAML as unlike JSON, map keys can have their own styling and tags and also use anchors and aliases.
 
 For instance to set the `style` of all nodes in a yaml doc, including the map keys:
 

--- a/pkg/yqlib/doc/operators/headers/recursive-descent-glob.md
+++ b/pkg/yqlib/doc/operators/headers/recursive-descent-glob.md
@@ -1,6 +1,6 @@
 # Recursive Descent (Glob)
 
-This operator recursively matches (or globs) all children nodes given of a particular element, including that node itself. This is most often used to apply a filter recursively against all matches. It can be used in either the 
+This operator recursively matches (or globs) all children nodes given of a particular element, including that node itself. This is most often used to apply a filter recursively against all matches.
 
 ## match values form `..`
 This will, like the `jq` equivalent, recursively match all _value_ nodes. Use it to find/manipulate particular values.

--- a/pkg/yqlib/doc/operators/headers/sort-keys.md
+++ b/pkg/yqlib/doc/operators/headers/sort-keys.md
@@ -10,7 +10,7 @@ yq -i -P 'sort_keys(..)' file2.yml
 diff file1.yml file2.yml
 ```
 
-Note that `yq` does not yet consider anchors when sorting by keys - this may result in invalid yaml documents if your are using merge anchors.
+Note that `yq` does not yet consider anchors when sorting by keys - this may result in invalid yaml documents if you are using merge anchors.
 
 For more advanced sorting, using `to_entries` to convert the map to an array, then sort/process the array as you like (e.g. using `sort_by`) and convert back to a map using `from_entries`.
 See [here](https://mikefarah.gitbook.io/yq/operators/entries#custom-sort-map-keys) for an example. 

--- a/pkg/yqlib/doc/operators/headers/string-operators.md
+++ b/pkg/yqlib/doc/operators/headers/string-operators.md
@@ -27,7 +27,7 @@ a: |
   cat
 ```
 
-Using `$( exp )` wont work, as it will trim the trailing new line.
+Using `$( exp )` wont work, as it will trim the trailing newline.
 
 ```
 m=$(echo "cat\n") yq -n '.a = strenv(m)'
@@ -49,7 +49,7 @@ a: |
   cat
 ```
 
-Similarly, if you're trying to set the content from a file, and want a trailing new line:
+Similarly, if you're trying to set the content from a file, and want a trailing newline:
 
 ```
 IFS= read -rd '' output < <(cat my_file)

--- a/pkg/yqlib/doc/operators/headers/string-operators.md
+++ b/pkg/yqlib/doc/operators/headers/string-operators.md
@@ -15,7 +15,7 @@ Capture returns named RegEx capture groups in a map. Can be more convenient than
 Returns true if the string matches the RegEx, false otherwise.
 
 ## sub(regEx, replacement)
-Substitutes matched substrings. The first parameter is the regEx to match substrings within the original string. The second is a what to replace those matches with. This can refer to capture groups from the first RegEx.
+Substitutes matched substrings. The first parameter is the regEx to match substrings within the original string. The second parameter specifies what to replace those matches with. This can refer to capture groups from the first RegEx.
 
 ## String blocks, bash and newlines
 Bash is notorious for chomping on precious trailing newline characters, making it tricky to set strings with newlines properly. In particular, the `$( exp )` _will trim trailing newlines_.

--- a/pkg/yqlib/doc/operators/headers/string-operators.md
+++ b/pkg/yqlib/doc/operators/headers/string-operators.md
@@ -1,7 +1,7 @@
 # String Operators
 
 ## RegEx
-This uses golangs native regex functions under the hood - See their [docs](https://github.com/google/re2/wiki/Syntax) for the supported syntax.
+This uses Golang's native regex functions under the hood - See their [docs](https://github.com/google/re2/wiki/Syntax) for the supported syntax.
 
 Case insensitive tip: prefix the regex with `(?i)` - e.g. `test("(?i)cats)"`.
 

--- a/pkg/yqlib/doc/operators/headers/subtract.md
+++ b/pkg/yqlib/doc/operators/headers/subtract.md
@@ -1,3 +1,3 @@
 # Subtract
 
-You can use subtract to subtract numbers, as well as removing elements from an array.
+You can use subtract to subtract numbers as well as remove elements from an array.

--- a/pkg/yqlib/doc/operators/headers/traverse-read.md
+++ b/pkg/yqlib/doc/operators/headers/traverse-read.md
@@ -1,3 +1,3 @@
 # Traverse (Read)
 
-This is the simplest (and perhaps most used) operator, it is used to navigate deeply into yaml structures.
+This is the simplest (and perhaps most used) operator. It is used to navigate deeply into yaml structures.

--- a/pkg/yqlib/doc/operators/line.md
+++ b/pkg/yqlib/doc/operators/line.md
@@ -29,7 +29,7 @@ b:
 ```
 then
 ```bash
-yq '.b | key| line' sample.yml
+yq '.b | key | line' sample.yml
 ```
 will output
 ```yaml

--- a/pkg/yqlib/doc/operators/multiply-merge.md
+++ b/pkg/yqlib/doc/operators/multiply-merge.md
@@ -477,7 +477,7 @@ b: !goat
 ```
 
 ## Custom types: clobber tags
-Use the `c` option to clobber custom tags. Note that the second tag is now used
+Use the `c` option to clobber custom tags. Note that the second tag is now used.
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/doc/operators/multiply-merge.md
+++ b/pkg/yqlib/doc/operators/multiply-merge.md
@@ -250,7 +250,7 @@ thing:
 ```
 
 ## Merge, deeply merging arrays
-Merging arrays deeply means arrays are merge like objects, with indexes as their key. In this case, we merge the first item in the array, and do nothing with the second.
+Merging arrays deeply means arrays are merged like objects, with indices as their key. In this case, we merge the first item in the array and do nothing with the second.
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/doc/operators/path.md
+++ b/pkg/yqlib/doc/operators/path.md
@@ -123,7 +123,7 @@ a:
 ```
 
 ## Set path to prune deep paths
-Like pick but recursive. This uses `ireduce` to deeply set the selected paths into an empty object,
+Like pick but recursive. This uses `ireduce` to deeply set the selected paths into an empty object.
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/doc/operators/pick.md
+++ b/pkg/yqlib/doc/operators/pick.md
@@ -27,7 +27,7 @@ myMap:
 ```
 
 ## Pick indices from array
-Note that the order of the indexes matches the pick order and non existent indexes are skipped.
+Note that the order of the indices matches the pick order and non existent indices are skipped.
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/doc/operators/recursive-descent-glob.md
+++ b/pkg/yqlib/doc/operators/recursive-descent-glob.md
@@ -12,7 +12,7 @@ yq '.. style= "flow"' file.yaml
 ```
 
 ## match values and map keys form `...`
-The also includes map keys in the results set. This is particularly useful in YAML as unlike JSON, map keys can have their own styling, tags and use anchors and aliases.
+The also includes map keys in the results set. This is particularly useful in YAML as unlike JSON, map keys can have their own styling and tags and also use anchors and aliases.
 
 For instance to set the `style` of all nodes in a yaml doc, including the map keys:
 

--- a/pkg/yqlib/doc/operators/recursive-descent-glob.md
+++ b/pkg/yqlib/doc/operators/recursive-descent-glob.md
@@ -1,6 +1,6 @@
 # Recursive Descent (Glob)
 
-This operator recursively matches (or globs) all children nodes given of a particular element, including that node itself. This is most often used to apply a filter recursively against all matches. It can be used in either the 
+This operator recursively matches (or globs) all children nodes given of a particular element, including that node itself. This is most often used to apply a filter recursively against all matches.
 
 ## match values form `..`
 This will, like the `jq` equivalent, recursively match all _value_ nodes. Use it to find/manipulate particular values.

--- a/pkg/yqlib/doc/operators/select.md
+++ b/pkg/yqlib/doc/operators/select.md
@@ -62,7 +62,7 @@ going
 ```
 
 ## Select elements from array with regular expression
-See more regular expression examples under the `string` operator docs.
+See more regular expression examples under the [`string` operator docs](https://mikefarah.gitbook.io/yq/operators/string-operators).
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/doc/operators/sort-keys.md
+++ b/pkg/yqlib/doc/operators/sort-keys.md
@@ -10,7 +10,7 @@ yq -i -P 'sort_keys(..)' file2.yml
 diff file1.yml file2.yml
 ```
 
-Note that `yq` does not yet consider anchors when sorting by keys - this may result in invalid yaml documents if your are using merge anchors.
+Note that `yq` does not yet consider anchors when sorting by keys - this may result in invalid yaml documents if you are using merge anchors.
 
 For more advanced sorting, using `to_entries` to convert the map to an array, then sort/process the array as you like (e.g. using `sort_by`) and convert back to a map using `from_entries`.
 See [here](https://mikefarah.gitbook.io/yq/operators/entries#custom-sort-map-keys) for an example. 

--- a/pkg/yqlib/doc/operators/string-operators.md
+++ b/pkg/yqlib/doc/operators/string-operators.md
@@ -27,7 +27,7 @@ a: |
   cat
 ```
 
-Using `$( exp )` wont work, as it will trim the trailing new line.
+Using `$( exp )` wont work, as it will trim the trailing newline.
 
 ```
 m=$(echo "cat\n") yq -n '.a = strenv(m)'
@@ -49,7 +49,7 @@ a: |
   cat
 ```
 
-Similarly, if you're trying to set the content from a file, and want a trailing new line:
+Similarly, if you're trying to set the content from a file, and want a trailing newline:
 
 ```
 IFS= read -rd '' output < <(cat my_file)

--- a/pkg/yqlib/doc/operators/string-operators.md
+++ b/pkg/yqlib/doc/operators/string-operators.md
@@ -298,7 +298,7 @@ false
 ```
 
 ## Substitute / Replace string
-This uses golang regex, described [here](https://github.com/google/re2/wiki/Syntax)
+This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax)
 Note the use of `|=` to run in context of the current string value.
 
 Given a sample.yml file of:
@@ -315,7 +315,7 @@ a: cats are great
 ```
 
 ## Substitute / Replace string with regex
-This uses golang regex, described [here](https://github.com/google/re2/wiki/Syntax)
+This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax)
 Note the use of `|=` to run in context of the current string value.
 
 Given a sample.yml file of:

--- a/pkg/yqlib/doc/operators/string-operators.md
+++ b/pkg/yqlib/doc/operators/string-operators.md
@@ -15,7 +15,7 @@ Capture returns named RegEx capture groups in a map. Can be more convenient than
 Returns true if the string matches the RegEx, false otherwise.
 
 ## sub(regEx, replacement)
-Substitutes matched substrings. The first parameter is the regEx to match substrings within the original string. The second is a what to replace those matches with. This can refer to capture groups from the first RegEx.
+Substitutes matched substrings. The first parameter is the regEx to match substrings within the original string. The second parameter specifies what to replace those matches with. This can refer to capture groups from the first RegEx.
 
 ## String blocks, bash and newlines
 Bash is notorious for chomping on precious trailing newline characters, making it tricky to set strings with newlines properly. In particular, the `$( exp )` _will trim trailing newlines_.

--- a/pkg/yqlib/doc/operators/string-operators.md
+++ b/pkg/yqlib/doc/operators/string-operators.md
@@ -1,7 +1,7 @@
 # String Operators
 
 ## RegEx
-This uses golangs native regex functions under the hood - See their [docs](https://github.com/google/re2/wiki/Syntax) for the supported syntax.
+This uses Golang's native regex functions under the hood - See their [docs](https://github.com/google/re2/wiki/Syntax) for the supported syntax.
 
 Case insensitive tip: prefix the regex with `(?i)` - e.g. `test("(?i)cats)"`.
 

--- a/pkg/yqlib/doc/operators/subtract.md
+++ b/pkg/yqlib/doc/operators/subtract.md
@@ -1,6 +1,6 @@
 # Subtract
 
-You can use subtract to subtract numbers, as well as removing elements from an array.
+You can use subtract to subtract numbers as well as remove elements from an array.
 
 ## Array subtraction
 Running

--- a/pkg/yqlib/doc/operators/subtract.md
+++ b/pkg/yqlib/doc/operators/subtract.md
@@ -59,24 +59,6 @@ a: -1.5
 b: 4.5
 ```
 
-## Number subtraction - float
-If the lhs or rhs are floats then the expression will be calculated with floats.
-
-Given a sample.yml file of:
-```yaml
-a: 3
-b: 4.5
-```
-then
-```bash
-yq '.a = .a - .b' sample.yml
-```
-will output
-```yaml
-a: -1.5
-b: 4.5
-```
-
 ## Number subtraction - int
 If both the lhs and rhs are ints then the expression will be calculated with ints.
 

--- a/pkg/yqlib/doc/operators/traverse-read.md
+++ b/pkg/yqlib/doc/operators/traverse-read.md
@@ -1,6 +1,6 @@
 # Traverse (Read)
 
-This is the simplest (and perhaps most used) operator, it is used to navigate deeply into yaml structures.
+This is the simplest (and perhaps most used) operator. It is used to navigate deeply into yaml structures.
 
 ## Simple map navigation
 Given a sample.yml file of:

--- a/pkg/yqlib/doc/operators/traverse-read.md
+++ b/pkg/yqlib/doc/operators/traverse-read.md
@@ -51,7 +51,7 @@ will output
 ```
 
 ## Special characters
-Use quotes with brackets around path elements with special characters
+Use quotes with square brackets around path elements with special characters
 
 Given a sample.yml file of:
 ```yaml
@@ -83,7 +83,7 @@ apple
 ```
 
 ## Keys with spaces
-Use quotes with brackets around path elements with special characters
+Use quotes with square brackets around path elements with special characters
 
 Given a sample.yml file of:
 ```yaml

--- a/pkg/yqlib/encoder_properties.go
+++ b/pkg/yqlib/encoder_properties.go
@@ -51,7 +51,7 @@ func (pe *propertiesEncoder) PrintLeadingContent(writer io.Writer, content strin
 
 		if errors.Is(errReading, io.EOF) {
 			if readline != "" {
-				// the last comment we read didn't have a new line, put one in
+				// the last comment we read didn't have a newline, put one in
 				if err := writeString(writer, "\n"); err != nil {
 					return err
 				}

--- a/pkg/yqlib/encoder_yaml.go
+++ b/pkg/yqlib/encoder_yaml.go
@@ -61,7 +61,7 @@ func (ye *yamlEncoder) PrintLeadingContent(writer io.Writer, content string) err
 
 		if errors.Is(errReading, io.EOF) {
 			if readline != "" {
-				// the last comment we read didn't have a new line, put one in
+				// the last comment we read didn't have a newline, put one in
 				if err := writeString(writer, "\n"); err != nil {
 					return err
 				}

--- a/pkg/yqlib/operator_anchors_aliases_test.go
+++ b/pkg/yqlib/operator_anchors_aliases_test.go
@@ -228,7 +228,7 @@ foobar:
 	},
 	{
 		description:    "Dereference and update a field",
-		subdescription: "`Use explode with multiply to dereference an object",
+		subdescription: "Use explode with multiply to dereference an object",
 		document:       simpleArrayRef,
 		expression:     `.thingOne |= explode(.) * {"value": false}`,
 		expected:       []string{expectedUpdatedArrayRef},

--- a/pkg/yqlib/operator_assign_test.go
+++ b/pkg/yqlib/operator_assign_test.go
@@ -196,7 +196,7 @@ var assignOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:           "Update node value that has an anchor",
-		subdescription:        "Anchor will remaple",
+		subdescription:        "Anchor will remain",
 		dontFormatInputForDoc: true,
 		document:              `a: &cool cat`,
 		expression:            `.a = "dog"`,

--- a/pkg/yqlib/operator_assign_test.go
+++ b/pkg/yqlib/operator_assign_test.go
@@ -230,7 +230,7 @@ var assignOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
-		description:    "Custom types: clovver",
+		description:    "Custom types: clobber",
 		subdescription: "Use the `c` option to clobber custom tags",
 		document:       "a: !cat meow\nb: !dog woof",
 		expression:     `.a =c .b`,

--- a/pkg/yqlib/operator_encoder_decoder.go
+++ b/pkg/yqlib/operator_encoder_decoder.go
@@ -79,13 +79,13 @@ func encodeOperator(d *dataTreeNavigator, context Context, expressionNode *Expre
 
 			original := originalList.Front().Value.(*CandidateNode)
 			originalNode := unwrapDoc(original.Node)
-			// original block did not have a new line at the end, get rid of this one too
+			// original block did not have a newline at the end, get rid of this one too
 			if !endWithNewLine.MatchString(originalNode.Value) {
 				stringValue = chomper.ReplaceAllString(stringValue, "")
 			}
 		}
 
-		// dont print a new line when printing json on a single line.
+		// dont print a newline when printing json on a single line.
 		if (preferences.format == JSONOutputFormat && preferences.indent == 0) ||
 			preferences.format == CSVOutputFormat ||
 			preferences.format == TSVOutputFormat {

--- a/pkg/yqlib/operator_encoder_decoder_test.go
+++ b/pkg/yqlib/operator_encoder_decoder_test.go
@@ -179,7 +179,7 @@ var encoderDecoderOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
-		description:    "Encode array of array scalars as tsv string",
+		description:    "Encode array of arrays as tsv string",
 		subdescription: "Scalars are strings, numbers and booleans.",
 		document:       `[[cat, "thing1,thing2", true, 3.40], [dog, thing3, false, 12]]`,
 		expression:     `@tsv`,

--- a/pkg/yqlib/operator_entries_test.go
+++ b/pkg/yqlib/operator_entries_test.go
@@ -36,7 +36,7 @@ var entriesOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
-		description:    "from_entries with numeric key indexes",
+		description:    "from_entries with numeric key indices",
 		subdescription: "from_entries always creates a map, even for numeric keys",
 		document:       `[a,b]`,
 		expression:     `to_entries | from_entries`,

--- a/pkg/yqlib/operator_line_test.go
+++ b/pkg/yqlib/operator_line_test.go
@@ -17,7 +17,7 @@ var lineOperatorScenarios = []expressionScenario{
 		description:    "Returns line of _key_ node",
 		subdescription: "Pipe through the key operator to get the line of the key",
 		document:       "a: cat\nb:\n   c: cat",
-		expression:     `.b | key| line`,
+		expression:     `.b | key | line`,
 		expected: []string{
 			"D0, P[b], (!!int)::2\n",
 		},

--- a/pkg/yqlib/operator_multiply_test.go
+++ b/pkg/yqlib/operator_multiply_test.go
@@ -420,7 +420,7 @@ var multiplyOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Merge, deeply merging arrays",
-		subdescription: "Merging arrays deeply means arrays are merge like objects, with indexes as their key. In this case, we merge the first item in the array, and do nothing with the second.",
+		subdescription: "Merging arrays deeply means arrays are merged like objects, with indices as their key. In this case, we merge the first item in the array and do nothing with the second.",
 		document:       `{a: [{name: fred, age: 12}, {name: bob, age: 32}], b: [{name: fred, age: 34}]}`,
 		expression:     `.a *d .b`,
 		expected: []string{

--- a/pkg/yqlib/operator_multiply_test.go
+++ b/pkg/yqlib/operator_multiply_test.go
@@ -525,7 +525,7 @@ var multiplyOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Custom types: clobber tags",
-		subdescription: "Use the `c` option to clobber custom tags. Note that the second tag is now used",
+		subdescription: "Use the `c` option to clobber custom tags. Note that the second tag is now used.",
 		document:       "a: !horse {cat: meow}\nb: !goat {dog: woof}",
 		expression:     ".a *=c .b",
 		expected: []string{
@@ -535,7 +535,7 @@ var multiplyOperatorScenarios = []expressionScenario{
 	{
 		skipDoc:        true,
 		description:    "Custom types: clobber tags - *=",
-		subdescription: "Use the `c` option to clobber custom tags - on both the `=` and `*` operator. Note that the second tag is now used",
+		subdescription: "Use the `c` option to clobber custom tags - on both the `=` and `*` operator. Note that the second tag is now used.",
 		document:       "a: !horse {cat: meow}\nb: !goat {dog: woof}",
 		expression:     ".a =c .a *c .b",
 		expected: []string{
@@ -545,7 +545,7 @@ var multiplyOperatorScenarios = []expressionScenario{
 	{
 		skipDoc:        true,
 		description:    "Custom types: dont clobber tags - *=",
-		subdescription: "Use the `c` option to clobber custom tags - on both the `=` and `*` operator. Note that the second tag is now used",
+		subdescription: "Use the `c` option to clobber custom tags - on both the `=` and `*` operator. Note that the second tag is now used.",
 		document:       "a: !horse {cat: meow}\nb: !goat {dog: woof}",
 		expression:     ".a *= .b",
 		expected: []string{

--- a/pkg/yqlib/operator_path_test.go
+++ b/pkg/yqlib/operator_path_test.go
@@ -90,7 +90,7 @@ var pathOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Set path to prune deep paths",
-		subdescription: "Like pick but recursive. This uses `ireduce` to deeply set the selected paths into an empty object,",
+		subdescription: "Like pick but recursive. This uses `ireduce` to deeply set the selected paths into an empty object.",
 		document:       documentToPrune,
 		expression:     "(.parentB.child2, .parentC.child1) as $i\n  ireduce({}; setpath($i | path; $i))",
 		expected: []string{

--- a/pkg/yqlib/operator_pick_test.go
+++ b/pkg/yqlib/operator_pick_test.go
@@ -34,7 +34,7 @@ var pickOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Pick indices from array",
-		subdescription: "Note that the order of the indexes matches the pick order and non existent indexes are skipped.",
+		subdescription: "Note that the order of the indices matches the pick order and non existent indices are skipped.",
 		document:       `[cat, leopard, lion]`,
 		expression:     `pick([2, 0, 734, -5])`,
 		expected: []string{

--- a/pkg/yqlib/operator_select_test.go
+++ b/pkg/yqlib/operator_select_test.go
@@ -57,7 +57,7 @@ var selectOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Select elements from array with regular expression",
-		subdescription: "See more regular expression examples under the `string` operator docs.",
+		subdescription: "See more regular expression examples under the [`string` operator docs](https://mikefarah.gitbook.io/yq/operators/string-operators).",
 		document:       `[this_0, not_this, nor_0_this, thisTo_4]`,
 		expression:     `.[] | select(test("[a-zA-Z]+_[0-9]$"))`,
 		expected: []string{

--- a/pkg/yqlib/operator_strings_test.go
+++ b/pkg/yqlib/operator_strings_test.go
@@ -205,7 +205,7 @@ var stringsOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Substitute / Replace string",
-		subdescription: "This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax)\nNote the use of `|=` to run in context of the current string value.",
+		subdescription: "This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax).\nNote the use of `|=` to run in context of the current string value.",
 		document:       `a: dogs are great`,
 		expression:     `.a |= sub("dogs", "cats")`,
 		expected: []string{
@@ -214,7 +214,7 @@ var stringsOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Substitute / Replace string with regex",
-		subdescription: "This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax)\nNote the use of `|=` to run in context of the current string value.",
+		subdescription: "This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax).\nNote the use of `|=` to run in context of the current string value.",
 		document:       "a: cat\nb: heat",
 		expression:     `.[] |= sub("(a)", "${1}r")`,
 		expected: []string{

--- a/pkg/yqlib/operator_strings_test.go
+++ b/pkg/yqlib/operator_strings_test.go
@@ -205,7 +205,7 @@ var stringsOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Substitute / Replace string",
-		subdescription: "This uses golang regex, described [here](https://github.com/google/re2/wiki/Syntax)\nNote the use of `|=` to run in context of the current string value.",
+		subdescription: "This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax)\nNote the use of `|=` to run in context of the current string value.",
 		document:       `a: dogs are great`,
 		expression:     `.a |= sub("dogs", "cats")`,
 		expected: []string{
@@ -214,7 +214,7 @@ var stringsOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Substitute / Replace string with regex",
-		subdescription: "This uses golang regex, described [here](https://github.com/google/re2/wiki/Syntax)\nNote the use of `|=` to run in context of the current string value.",
+		subdescription: "This uses Golang's regex, described [here](https://github.com/google/re2/wiki/Syntax)\nNote the use of `|=` to run in context of the current string value.",
 		document:       "a: cat\nb: heat",
 		expression:     `.[] |= sub("(a)", "${1}r")`,
 		expected: []string{

--- a/pkg/yqlib/operator_subtract_test.go
+++ b/pkg/yqlib/operator_subtract_test.go
@@ -68,15 +68,6 @@ var subtractOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
-		description:    "Number subtraction - float",
-		subdescription: "If the lhs or rhs are floats then the expression will be calculated with floats.",
-		document:       `{a: 3, b: 4.5}`,
-		expression:     `.a = .a - .b`,
-		expected: []string{
-			"D0, P[], (doc)::{a: -1.5, b: 4.5}\n",
-		},
-	},
-	{
 		description:    "Number subtraction - int",
 		subdescription: "If both the lhs and rhs are ints then the expression will be calculated with ints.",
 		document:       `{a: 3, b: 4}`,

--- a/pkg/yqlib/operator_traverse_path.go
+++ b/pkg/yqlib/operator_traverse_path.go
@@ -89,7 +89,7 @@ func traverseArrayOperator(d *dataTreeNavigator, context Context, expressionNode
 		return Context{}, err
 	}
 
-	// rhs is a collect expression that will yield indexes to retrieve of the arrays
+	// rhs is a collect expression that will yield indices to retrieve of the arrays
 
 	rhs, err := d.GetMatchingNodes(context.ReadOnlyClone(), expressionNode.RHS)
 
@@ -267,7 +267,7 @@ func traverseMap(context Context, matchingNode *CandidateNode, keyNode *yaml.Nod
 
 func doTraverseMap(newMatches *orderedmap.OrderedMap, candidate *CandidateNode, wantedKey string, prefs traversePreferences, splat bool) error {
 	// value.Content is a concatenated array of key, value,
-	// so keys are in the even indexes, values in odd.
+	// so keys are in the even indices, values in odd.
 	// merge aliases are defined first, but we only want to traverse them
 	// if we don't find a match directly on this node first.
 

--- a/pkg/yqlib/operator_traverse_path_test.go
+++ b/pkg/yqlib/operator_traverse_path_test.go
@@ -116,7 +116,7 @@ var traversePathOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Special characters",
-		subdescription: "Use quotes with brackets around path elements with special characters",
+		subdescription: "Use quotes with square brackets around path elements with special characters",
 		document:       `{"{}": frog}`,
 		expression:     `.["{}"]`,
 		expected: []string{
@@ -133,7 +133,7 @@ var traversePathOperatorScenarios = []expressionScenario{
 	},
 	{
 		description:    "Keys with spaces",
-		subdescription: "Use quotes with brackets around path elements with special characters",
+		subdescription: "Use quotes with square brackets around path elements with special characters",
 		document:       `{"red rabbit": frog}`,
 		expression:     `.["red rabbit"]`,
 		expected: []string{

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -27,7 +27,7 @@
 
 4.30.6:
   - Fixed xml comment in array of scalars #1465
-  - Include blank new lines in leading header preprocessing #1462
+  - Include blank newlines in leading header preprocessing #1462
   - Added aarch64 build (#1261)
   - Bumped dependency versions (#1453)
 

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -171,7 +171,7 @@
 
 4.24.1:
   - Added comparison operators! (#94)
-  - Bumped golang to 1.18 (#1153)
+  - Bumped Golang to 1.18 (#1153)
   - XML parser no longer runs in strict mode (added new flag to run in strict mode) (#1155)
 
 4.23.1:

--- a/scripts/release-deb.sh
+++ b/scripts/release-deb.sh
@@ -28,7 +28,7 @@ show_help() {
   echo "    -h, --help		              Shows this help"
   echo "    -d, --distribution DISTRO   The distribution to use for the changelog generation. If not provided, last changelog entry"
   echo "                                  distribution is considered"
-  echo "    --goversion VERSION         The version of golang to use. Default to $GOVERSION"
+  echo "    --goversion VERSION         The version of Golang to use. Default to $GOVERSION"
   echo "    -k, --sign-key KEYID        Sign the package sources with the provided gpg key id (long format). When not provided this"
   echo "                                  paramater, the generated sources are not signed"
   echo "    -s, --sign                  Sign the package sources with a gpg key of the maintainer"
@@ -156,7 +156,7 @@ fi
 # generate changelog
 gbp dch --ignore-branch --no-multimaint -N "$VERSION" -s "\$SINCE" -D "\$DISTRIBUTION"
 
-# using -d to prevent failing when searching for golang dep on control file
+# using -d to prevent failing when searching for Golang dep on control file
 params=("-d" "-S")
 
 # add the -sa option for signing along with the key to use when provided key id
@@ -208,7 +208,7 @@ RUN set -e \
   && sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list \
   && apt-get -qq update
 
-# install golang on its $GOVERSION
+# install Golang on its $GOVERSION
 FROM base as golang
 RUN apt-get -qq -y --no-install-recommends install \
     ca-certificates \


### PR DESCRIPTION
This PR addresses a few minor typos, rewords a few sentences and removes a duplicate test case. `go test ./...` at the root of the project completed successfully.