### PR TITLE
Add support for decoding base64 strings without padding

### DIFF
--- a/pkg/yqlib/operator_encoder_decoder_test.go
+++ b/pkg/yqlib/operator_encoder_decoder_test.go
@@ -311,6 +311,14 @@ var encoderDecoderOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
+		description: "base64 missing padding test",
+		skipDoc:     true,
+		expression:  `"Y2F0cw" | @base64d`,
+		expected: []string{
+			"D0, P[], (!!str)::cats\n",
+		},
+	},
+	{
 		requiresFormat: "xml",
 		description:    "empty xml decode",
 		skipDoc:        true,


### PR DESCRIPTION
fixes #1555

Kinda tricky to fix because the encode decode operator is very generic so it's an awkward place to put a conditional to handle just unpadded base64 strings.

The base64Decoder itself just holds a Reader so it had no idea how long the data is.
