### PR TITLE
Add removable-media interface plug declaration to the snap packaging(#1618)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ confinement: strict
 apps:
   yq:
     command: yq
-    plugs: [home]
+    plugs: [home, removable-media]
 parts:
   yq:
     plugin: go


### PR DESCRIPTION
Allow snap users to process YAML documents under /media or /mnt paths after connecting to the `removable-media` snapd slot:

```
sudo snap connect yq :removable-media
```

Fixes #1618.