### PR TITLE
fix:  runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/pkg/yqlib/decoder_json.go
+++ b/pkg/yqlib/decoder_json.go
@@ -46,6 +46,9 @@ func (dec *jsonDecoder) Decode() (*CandidateNode, error) {
 }
 
 func (dec *jsonDecoder) convertToYamlNode(data *orderedMap) (*yaml.Node, error) {
+	if data == nil {
+		return createScalarNode(nil, "null"), nil
+	}
 	if data.kv == nil {
 		switch rawData := data.altVal.(type) {
 		case nil:


### PR DESCRIPTION
Resolve error: 
``` runtime error: invalid memory address or nil pointer dereference ```

The case of error occurs when in the documentation we have a reference to an object in the array null.

Exp Json (Generated of python Library auto documentation Swagger [drf-spectacular]):
```

"NullEnum": {
      "enum": [
          null
      ]
  }

Use this in property another object where of property type Enum is Nullable:

"profile_enum": {
                        "nullable": true,
                        "oneOf": [
                            {
                                "$ref": "#/components/schemas/ProfileEnumEnum"
                            },
                            {
                                "$ref": "#/components/schemas/NullEnum"
                            }
                        ]
                    }

```

I performed the YAML to JSON conversion test in the swagger-editor and was successful, with that I opened this suggestion so that it does not generate problems in the conversion.