### PR TITLE
Improve comparing tips document

### DIFF
--- a/usage/tips-and-tricks.md
+++ b/usage/tips-and-tricks.md
@@ -148,7 +148,7 @@ yq -n '.someNew="content"' > newfile.yml
 The best way to run a diff is to use `yq` to normalise the yaml files and then just use diff. Here is a simple example of using pretty print `-P` to normalise the styling and running diff:
 
 ```
-diff <(yq -P 'sort_keys(..)' file1.yaml) <(yq -P 'sort_keys(..)' file2.yaml)
+diff <(yq -P 'sort_keys(..)' -o=props file1.yaml) <(yq -P 'sort_keys(..)' -o=props file2.yaml)
 ```
 
 This way you can use the full power of `diff` and normalise the yaml files as you like.


### PR DESCRIPTION

## Change

Currently, it's difficult to read the differences between nodes with the same name but different parent nodes, as the current command does not display the parent nodes.

```
$ diff <(yq -P 'sort_keys(..)' file1.yaml) <(yq -P 'sort_keys(..)' file2.yaml)
4c4
<     key2: value2
---
>     key3: value3
7c7
<     key2: value2
---
>     key2: value4
```

To make the output more readable, I've added the `-o=props` option.

```
$ diff <(yq -P 'sort_keys(..)' -o=props file1.yaml) <(yq -P 'sort_keys(..)' -o=props file2.yaml)
2c2
< path1.path2.key2 = value2
---
> path1.path2.key3 = value3
4c4
< path1.path3.key2 = value2
---
> path1.path3.key2 = value4
```


file1.yaml
```yaml
path1:
  path2:
    key1: value1
    key2: value2
  path3:
    key1: value1
    key2: value2
```

file2.yaml
```yaml
path1:
  path2:
    key1: value1
    key3: value3
  path3:
    key1: value1
    key2: value4
```