### PR TITLE
Lua output fixes

### DIFF
--- a/acceptance_tests/output-format.sh
+++ b/acceptance_tests/output-format.sh
@@ -271,4 +271,43 @@ EOM
   assertEquals "$expected" "$X"
 }
 
+testLuaOutputPretty() {
+  cat >test.yml <<EOL
+animals:
+  cat: meow
+EOL
+
+  read -r -d '' expected << EOM
+return {
+	["animals"] = {
+		["cat"] = "meow";
+	};
+};
+EOM
+
+  X=$(./yq e --output-format=lua test.yml)
+  assertEquals "$expected" "$X"
+
+  X=$(./yq e --output-format=lua --prettyPrint test.yml)
+  assertEquals "$expected" "$X"
+
+}
+
+testLuaOutputSubset() {
+  cat >test.yml <<EOL
+animals:
+  cat: meow
+EOL
+
+  read -r -d '' expected << EOM
+return {
+	["cat"] = "meow";
+};
+EOM
+
+  X=$(./yq e --output-format=lua '.animals' test.yml)
+  assertEquals "$expected" "$X"
+
+}
+
 source ./scripts/shunit2

--- a/pkg/yqlib/doc/usage/lua.md
+++ b/pkg/yqlib/doc/usage/lua.md
@@ -129,6 +129,8 @@ numbers:
   - octal: 0o30
   - float: 123.45
   - infinity: .inf
+    plus_infinity: +.inf
+    minus_infinity: -.inf
   - not: .nan
 
 ```
@@ -162,6 +164,8 @@ return {
 		},
 		{
 			["infinity"] = (1/0);
+			["plus_infinity"] = (1/0);
+			["minus_infinity"] = (-1/0);
 		},
 		{
 			["not"] = (0/0);

--- a/pkg/yqlib/encoder_lua.go
+++ b/pkg/yqlib/encoder_lua.go
@@ -292,7 +292,7 @@ func (le *luaEncoder) encodeAny(writer io.Writer, node *yaml.Node) error {
 			return writeString(writer, strings.ToLower(node.Value))
 		case "!!float":
 			switch strings.ToLower(node.Value) {
-			case ".inf":
+			case ".inf", "+.inf":
 				return writeString(writer, "(1/0)")
 			case "-.inf":
 				return writeString(writer, "(-1/0)")

--- a/pkg/yqlib/encoder_lua.go
+++ b/pkg/yqlib/encoder_lua.go
@@ -270,7 +270,7 @@ func (le *luaEncoder) encodeAny(writer io.Writer, node *yaml.Node) error {
 	case yaml.MappingNode:
 		return le.encodeMap(writer, node, false)
 	case yaml.ScalarNode:
-		switch node.Tag {
+		switch node.ShortTag() {
 		case "!!str":
 			return le.encodeString(writer, node)
 		case "!!null":

--- a/pkg/yqlib/encoder_lua.go
+++ b/pkg/yqlib/encoder_lua.go
@@ -129,7 +129,7 @@ func (le *luaEncoder) encodeArray(writer io.Writer, node *yaml.Node) error {
 		if err != nil {
 			return err
 		}
-		err := le.Encode(writer, child)
+		err := le.encodeAny(writer, child)
 		if err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ func (le *luaEncoder) encodeMap(writer io.Writer, node *yaml.Node, global bool) 
 	for i, child := range node.Content {
 		if (i % 2) == 1 {
 			// value
-			err := le.Encode(writer, child)
+			err := le.encodeAny(writer, child)
 			if err != nil {
 				return err
 			}
@@ -305,26 +305,33 @@ func (le *luaEncoder) encodeAny(writer io.Writer, node *yaml.Node) error {
 			return fmt.Errorf("Lua encoder NYI -- %s", node.ShortTag())
 		}
 	case yaml.DocumentNode:
-		if le.globals {
-			if node.Content[0].Kind != yaml.MappingNode {
-				return fmt.Errorf("--lua-global requires a top level MappingNode")
-			}
-			return le.encodeMap(writer, node.Content[0], true)
-		}
-		err := writeString(writer, le.docPrefix)
-		if err != nil {
-			return err
-		}
-		err = le.encodeAny(writer, node.Content[0])
-		if err != nil {
-			return err
-		}
-		return writeString(writer, le.docSuffix)
+		return le.encodeAny(writer, node.Content[0])
 	default:
 		return fmt.Errorf("Lua encoder NYI -- %s", node.ShortTag())
 	}
 }
 
+func (le *luaEncoder) encodeTopLevel(writer io.Writer, node *yaml.Node) error {
+	err := writeString(writer, le.docPrefix)
+	if err != nil {
+		return err
+	}
+	err = le.encodeAny(writer, node)
+	if err != nil {
+		return err
+	}
+	return writeString(writer, le.docSuffix)
+}
+
 func (le *luaEncoder) Encode(writer io.Writer, node *yaml.Node) error {
-	return le.encodeAny(writer, node)
+	if node.Kind == yaml.DocumentNode {
+		return le.Encode(writer, node.Content[0])
+	}
+	if le.globals {
+		if node.Kind != yaml.MappingNode {
+			return fmt.Errorf("--lua-global requires a top level MappingNode")
+		}
+		return le.encodeMap(writer, node, true)
+	}
+	return le.encodeTopLevel(writer, node)
 }

--- a/pkg/yqlib/lua_test.go
+++ b/pkg/yqlib/lua_test.go
@@ -135,6 +135,8 @@ numbers:
   - octal: 0o30
   - float: 123.45
   - infinity: .inf
+    plus_infinity: +.inf
+    minus_infinity: -.inf
   - not: .nan
 `,
 		expected: `return {
@@ -161,6 +163,8 @@ numbers:
 		},
 		{
 			["infinity"] = (1/0);
+			["plus_infinity"] = (1/0);
+			["minus_infinity"] = (-1/0);
 		},
 		{
 			["not"] = (0/0);


### PR DESCRIPTION
Fixes for some quirks noticed while working on #1810 

- `+.inf` was not handled
- `yq -o lua .foo <<< '{"foo":{"bar":1}}` or the `--prettyPrint` flag would output `{bar=1}` only, without the pre- & suffix.
- Handle empty `Tag` field, if the parser side does not set it (I did before finding a good way to distinguish integer and float in the Lua parser)

Could split into multiple PRs if that is desirable. 