### PR TITLE
Fixes #1692 - Inconsistent backslash escaping in literal strings

### DIFF
--- a/pkg/yqlib/lexer_participle.go
+++ b/pkg/yqlib/lexer_participle.go
@@ -369,8 +369,8 @@ func stringValue() yqAction {
 		log.Debug("rawTokenvalue: %v", rawToken.Value)
 		value := unwrap(rawToken.Value)
 		log.Debug("unwrapped: %v", value)
-		value = strings.ReplaceAll(value, "\\\"", "\"")
-		value = strings.ReplaceAll(value, "\\n", "\n")
+		replacer := strings.NewReplacer("\\\\", "\\", "\\\"", "\"", "\\n", "\n")
+		value = replacer.Replace(value)
 		log.Debug("replaced: %v", value)
 		return &token{TokenType: operationToken, Operation: createValueOperation(value, value)}, nil
 	}


### PR DESCRIPTION
This is the simplest fix I can come up with for #1692

Before:
```sh
% yq -nr eval '"\\"'
\\
```

After:
```sh
% yq -nr eval '"\\"'
\
```

It does change behaviour.  Anyone who is currently using double backslashes in their literal strings will need to change them to quadruple backslashes.

It also makes it possible to use a literal string of a windows path for a filename that starts with `n`:
```
% yq -nr eval '"C:\\tmp\\nigel.xlsx"'
C:\tmp\nigel.xlsx
```