### PR TITLE
Missing dependencies to build application

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,5 +6,7 @@ RUN set -e -x \
     && /opt/devtools.sh
 ENV PATH=/go/bin:$PATH
 
+RUN apt-get update && apt-get install -y npm && npm install -g npx cspell@latest
+
 ENV CGO_ENABLED 0
 ENV GOPATH /go:/yq


### PR DESCRIPTION
Currently it's not possible to build the application with `make` due to missing dependencies in the docker container.
The goal of this PR is to add these missing dependencies.