### PR TITLE
add tests for root node unwrap bug in previous versions

### DIFF
--- a/acceptance_tests/output-format.sh
+++ b/acceptance_tests/output-format.sh
@@ -72,6 +72,15 @@ EOL
   assertEquals "\"cat\"" "$X"
 }
 
+testOutputYamlRawOnRoot() {
+  cat >test.yml <<EOL
+'a'
+EOL
+
+  X=$(./yq e -r '.' test.yml)
+  assertEquals "a" "$X"
+}
+
 testOutputJsonRaw() {
   cat >test.yml <<EOL
 a: cat

--- a/pkg/yqlib/printer_test.go
+++ b/pkg/yqlib/printer_test.go
@@ -390,3 +390,23 @@ func TestPrinterNulSeparatorWithJson(t *testing.T) {
 	writer.Flush()
 	test.AssertResult(t, expected, output.String())
 }
+
+func TestPrinterRootUnwrap(t *testing.T) {
+	var output bytes.Buffer
+	var writer = bufio.NewWriter(&output)
+	printer := NewSimpleYamlPrinter(writer, YamlOutputFormat, true, false, 2, false)
+	node, err := getExpressionParser().ParseExpression(".")
+	if err != nil {
+		panic(err)
+	}
+	streamEvaluator := NewStreamEvaluator()
+	_, err = streamEvaluator.Evaluate("sample", strings.NewReader("'a'"), node, printer, NewYamlDecoder(ConfiguredYamlPreferences))
+	if err != nil {
+		panic(err)
+	}
+
+	writer.Flush()
+    expected := `a
+`
+	test.AssertResult(t, expected, output.String())
+}


### PR DESCRIPTION
Well, I found a bug, and was ready to fix it when I saw that your recent commit labelled `Generic AST` fixed it. If you are interested, here are the tests I wrote before trying to fix this bug. Every currently published releases (up to `v4.35.2`) have this bug:

```
$ echo "'a'" | ./yq -r '.'  ## fails to unwrap
'a'
$ echo "'a'" | ./yq -r '. + ""'  ## works fine
a
```
