### PR TITLE
Do not panic when StdIn is closed

### DIFF
--- a/acceptance_tests/basic.sh
+++ b/acceptance_tests/basic.sh
@@ -362,6 +362,12 @@ EOM
   assertEquals "$expected" "$X"
 }
 
-
+testBasicClosedStdIn() {
+  cat >test.yml <<EOL
+a: 1
+EOL
+  X=$(./yq e '.a' test.yml <&-)
+  assertEquals "1" "$X"
+}
 
 source ./scripts/shunit2

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -227,8 +227,11 @@ func maybeFile(str string) bool {
 }
 
 func processStdInArgs(args []string) []string {
-	stat, _ := os.Stdin.Stat()
-	pipingStdin := (stat.Mode() & os.ModeCharDevice) == 0
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		yqlib.GetLogger().Debugf("error getting stdin: %v", err)
+	}
+	pipingStdin := stat != nil && (stat.Mode()&os.ModeCharDevice) == 0
 
 	// if we've been given a file, don't automatically
 	// read from stdin.


### PR DESCRIPTION
Hi, this PR proposes a fix for scenarios when `yq` executes in an env with stdin closed. It also adds an acceptance test case for this scenario.

When the shell executing yq has no open stdin, os.Stdin.Stat() returns nil, and yq fails to continue. This commit fixes a missing verification on the result of os.Stdin.Stat() in the utils.processStdInArgs function and adds an acceptance test to cover this scenario in the future. This bug has affected yq since version 4.26.1.

It is reproducible till the latest version in master by:

```shell
cat >test.yml <<EOL
a: 1
EOL
./yq e test.yml <&-
```

Fixes #1868