### PR TITLE
snap: update and migrate to core22.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,17 +3,16 @@ version: 'v4.40.5'
 summary: A lightweight and portable command-line data file processor
 description: |
   `yq` uses [jq](https://github.com/stedolan/jq) like syntax but works with yaml, json, xml, csv, properties and TOML files.
-base: core18
+base: core22
 grade: stable # devel|stable. must be 'stable' to release into candidate/stable channels
 confinement: strict
 apps:
   yq:
-    command: yq
+    command: bin/yq
     plugs: [home, removable-media]
 parts:
   yq:
     plugin: go
-    go-channel: 1.20/stable
     source: .
-    source-type: git
-    go-importpath: github.com/mikefarah/yq
+    build-snaps:
+      - go/1.20/stable


### PR DESCRIPTION
soon, core24 is gonna release. But for now core22 is stable and a better option. So, ported to core24.