### PR TITLE
Add --properties-separator option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,6 +120,8 @@ yq -P -oy sample.json
 	rootCmd.PersistentFlags().BoolVar(&yqlib.ConfiguredLuaPreferences.UnquotedKeys, "lua-unquoted", yqlib.ConfiguredLuaPreferences.UnquotedKeys, "output unquoted string keys (e.g. {foo=\"bar\"})")
 	rootCmd.PersistentFlags().BoolVar(&yqlib.ConfiguredLuaPreferences.Globals, "lua-globals", yqlib.ConfiguredLuaPreferences.Globals, "output keys as top-level global variables")
 
+	rootCmd.PersistentFlags().StringVar(&yqlib.ConfiguredPropertiesPreferences.KeyValueSeparator, "properties-separator", yqlib.ConfiguredPropertiesPreferences.KeyValueSeparator, "separator to use between keys and values")
+
 	rootCmd.PersistentFlags().BoolVarP(&nullInput, "null-input", "n", false, "Don't read input, simply evaluate the expression given. Useful for creating docs from scratch.")
 	rootCmd.PersistentFlags().BoolVarP(&noDocSeparators, "no-doc", "N", false, "Don't print document separators (---)")
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -187,7 +187,7 @@ func createEncoder(format yqlib.PrinterOutputFormat) (yqlib.Encoder, error) {
 	case yqlib.JSONOutputFormat:
 		return yqlib.NewJSONEncoder(indent, colorsEnabled, unwrapScalar), nil
 	case yqlib.PropsOutputFormat:
-		return yqlib.NewPropertiesEncoder(unwrapScalar), nil
+		return yqlib.NewPropertiesEncoder(unwrapScalar, yqlib.ConfiguredPropertiesPreferences), nil
 	case yqlib.CSVOutputFormat:
 		return yqlib.NewCsvEncoder(yqlib.ConfiguredCsvPreferences), nil
 	case yqlib.TSVOutputFormat:

--- a/pkg/yqlib/doc/usage/properties.md
+++ b/pkg/yqlib/doc/usage/properties.md
@@ -120,6 +120,36 @@ emptyArray =
 emptyMap = 
 ```
 
+## Encode properties: use custom separator
+Provide a custom key-value separator using the `--properties-separator` flag.
+
+Given a sample.yml file of:
+```yaml
+# block comments come through
+person: # neither do comments on maps
+    name: Mike Wazowski # comments on values appear
+    pets: 
+    - cat # comments on array values appear
+    food: [pizza] # comments on arrays do not
+emptyArray: []
+emptyMap: []
+
+```
+then
+```bash
+yq -o props --properties-separator=";" sample.yml
+```
+will output
+```properties
+# block comments come through
+# comments on values appear
+person.name;Mike Wazowski
+
+# comments on array values appear
+person.pets.0;cat
+person.food.0;pizza
+```
+
 ## Decode properties
 Given a sample.properties file of:
 ```properties

--- a/pkg/yqlib/encoder_properties.go
+++ b/pkg/yqlib/encoder_properties.go
@@ -12,11 +12,13 @@ import (
 
 type propertiesEncoder struct {
 	unwrapScalar bool
+	prefs        PropertiesPreferences
 }
 
-func NewPropertiesEncoder(unwrapScalar bool) Encoder {
+func NewPropertiesEncoder(unwrapScalar bool, prefs PropertiesPreferences) Encoder {
 	return &propertiesEncoder{
 		unwrapScalar: unwrapScalar,
+		prefs:        prefs,
 	}
 }
 
@@ -69,6 +71,7 @@ func (pe *propertiesEncoder) Encode(writer io.Writer, node *CandidateNode) error
 
 	mapKeysToStrings(node)
 	p := properties.NewProperties()
+	p.WriteSeparator = pe.prefs.KeyValueSeparator
 	err := pe.doEncode(p, node, "", nil)
 	if err != nil {
 		return err

--- a/pkg/yqlib/operator_encoder_decoder.go
+++ b/pkg/yqlib/operator_encoder_decoder.go
@@ -14,7 +14,7 @@ func configureEncoder(format PrinterOutputFormat, indent int) Encoder {
 	case JSONOutputFormat:
 		return NewJSONEncoder(indent, false, false)
 	case PropsOutputFormat:
-		return NewPropertiesEncoder(true)
+		return NewPropertiesEncoder(true, ConfiguredPropertiesPreferences)
 	case CSVOutputFormat:
 		return NewCsvEncoder(ConfiguredCsvPreferences)
 	case TSVOutputFormat:

--- a/pkg/yqlib/properties.go
+++ b/pkg/yqlib/properties.go
@@ -1,0 +1,13 @@
+package yqlib
+
+type PropertiesPreferences struct {
+	KeyValueSeparator string
+}
+
+func NewDefaultPropertiesPreferences() PropertiesPreferences {
+	return PropertiesPreferences{
+		KeyValueSeparator: " = ",
+	}
+}
+
+var ConfiguredPropertiesPreferences = NewDefaultPropertiesPreferences()

--- a/pkg/yqlib/properties_test.go
+++ b/pkg/yqlib/properties_test.go
@@ -272,7 +272,7 @@ func documentUnwrappedEncodePropertyScenario(w *bufio.Writer, s formatScenario) 
 	}
 	writeOrPanic(w, "will output\n")
 
-	writeOrPanic(w, fmt.Sprintf("```properties\n%v```\n\n", mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(true))))
+	writeOrPanic(w, fmt.Sprintf("```properties\n%v```\n\n", mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(true, ConfiguredPropertiesPreferences))))
 }
 
 func documentWrappedEncodePropertyScenario(w *bufio.Writer, s formatScenario) {
@@ -297,7 +297,7 @@ func documentWrappedEncodePropertyScenario(w *bufio.Writer, s formatScenario) {
 	}
 	writeOrPanic(w, "will output\n")
 
-	writeOrPanic(w, fmt.Sprintf("```properties\n%v```\n\n", mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(false))))
+	writeOrPanic(w, fmt.Sprintf("```properties\n%v```\n\n", mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(false, ConfiguredPropertiesPreferences))))
 }
 
 func documentDecodePropertyScenario(w *bufio.Writer, s formatScenario) {
@@ -347,7 +347,7 @@ func documentRoundTripPropertyScenario(w *bufio.Writer, s formatScenario) {
 
 	writeOrPanic(w, "will output\n")
 
-	writeOrPanic(w, fmt.Sprintf("```properties\n%v```\n\n", mustProcessFormatScenario(s, NewPropertiesDecoder(), NewPropertiesEncoder(true))))
+	writeOrPanic(w, fmt.Sprintf("```properties\n%v```\n\n", mustProcessFormatScenario(s, NewPropertiesDecoder(), NewPropertiesEncoder(true, ConfiguredPropertiesPreferences))))
 }
 
 func documentPropertyScenario(_ *testing.T, w *bufio.Writer, i interface{}) {
@@ -374,13 +374,13 @@ func TestPropertyScenarios(t *testing.T) {
 	for _, s := range propertyScenarios {
 		switch s.scenarioType {
 		case "":
-			test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(true)), s.description)
+			test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(true, ConfiguredPropertiesPreferences)), s.description)
 		case "decode":
 			test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewPropertiesDecoder(), NewYamlEncoder(2, false, ConfiguredYamlPreferences)), s.description)
 		case "encode-wrapped":
-			test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(false)), s.description)
+			test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewPropertiesEncoder(false, ConfiguredPropertiesPreferences)), s.description)
 		case "roundtrip":
-			test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewPropertiesDecoder(), NewPropertiesEncoder(true)), s.description)
+			test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewPropertiesDecoder(), NewPropertiesEncoder(true, ConfiguredPropertiesPreferences)), s.description)
 
 		default:
 			panic(fmt.Sprintf("unhandled scenario type %q", s.scenarioType))


### PR DESCRIPTION
Hello! I love using `yq` and wanted to spend some free time contributing. I saw #1864 and thought I'd give it a shot. If there's anything I'm missing, please feel free to let me know. Thanks!

Here's the commit desc. for convenience:

This commit adds the --properties-separator option, which lets users specify the separator used between keys and values in the properties output format. This is done by adjusting the value of github.com/magiconair/properties#Properties.WriteSeparator at encode time.

Some refactoring of the properties encoder unit tests was done to make it easier to write unit tests that include different separator values.

Fixes: #1864
