### PR TITLE
doc: minor typo fix on example

### DIFF
--- a/usage/tips-and-tricks.md
+++ b/usage/tips-and-tricks.md
@@ -172,7 +172,7 @@ yq '.apple' <(curl -s https://somewhere/data1.yaml) <(cat file.yml)
 The most important thing to remember to do is to have brackets around the LHS expression - otherwise what `yq` will do is first filter by the selection, and then, separately, update the filtered result and return that subset.
 
 ```
-yq '(.foo.bar[] | select(name == "fred) | .apple) = "cool"'
+yq '(.foo.bar[] | select(.name == "fred") | .apple) = "cool"'
 ```
 
 ## Combining multiple files into one


### PR DESCRIPTION
Fixes a typo found in the example in the following topic in the docs:
https://mikefarah.gitbook.io/yq/usage/tips-and-tricks#updating-deeply-selected-paths

While I was reading the documentation and testing this (amazing) tool, I came across an error in the example that this Pull Request fixes. My tests involved rewriting a given file with the flag -i.

As it stands, when trying to run the example command an error similar to this is returned:
`Error: 1:30: invalid input text "name == \"fred) | ..."`

The proposed fix brings the example into line with expected behavior.