### PR TITLE
Use static bin in snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,8 @@ apps:
 parts:
   yq:
     plugin: go
+    build-environment:
+      - CGO_ENABLED: 0
     source: https://github.com/mikefarah/yq.git
     source-tag: v4.44.2
     build-snaps:


### PR DESCRIPTION
# Description
This PR modifies the snapcraft.yaml file used to build the snap package to set `CGO_ENABLED=0` during the build.

While normally a dynamic executable is not an issue for snaps since they are already running in an isolated environment, there is one use case this would improve. The `stage-snaps` directive is a snapcraft.yaml keyword one can use when building a snap to dump the contents of another snap. I ran into an issue where a snap I am building is based on core20 and using `yq`, after yq's update to core22, I ran into errors when my snap would try and run `yq` saying that glibc versions can't be found.

The documentation for stage-snaps can be found [here](https://snapcraft.io/docs/build-and-staging-dependencies).
The issue with staging snaps built on a different base is explained further [here](https://forum.snapcraft.io/t/snapcraft-should-fail-or-warn-when-using-a-stage-snap-with-different-base/21228).

# Testing
Run the following:
- `snapcraft clean`
- `snapcraft`
- `mkdir -p /mnt/snap`
- `sudo mount -t squashfs -o ro ./yq_v4.44.2_amd64.snap /mnt/snap`
- `ldd /mnt/snap/bin/yq`

Output:
`not a dynamic executable`