### PR TITLE
convert file ext to lowercase for format detection

### DIFF
--- a/pkg/yqlib/format.go
+++ b/pkg/yqlib/format.go
@@ -2,6 +2,7 @@ package yqlib
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -107,12 +108,11 @@ func (f *Format) GetConfiguredEncoder() Encoder {
 }
 
 func FormatStringFromFilename(filename string) string {
-
 	if filename != "" {
-		GetLogger().Debugf("checking file extension '%s' for auto format detection", filename)
-		nPos := strings.LastIndex(filename, ".")
-		if nPos > -1 {
-			format := strings.ToLower(filename[nPos+1:])
+		GetLogger().Debugf("checking filename '%s' for auto format detection", filename)
+		ext := filepath.Ext(filename)
+		if ext != "" && ext[0] == '.' {
+			format := strings.ToLower(ext[1:])
 			GetLogger().Debugf("detected format '%s'", format)
 			return format
 		}

--- a/pkg/yqlib/format.go
+++ b/pkg/yqlib/format.go
@@ -112,7 +112,7 @@ func FormatStringFromFilename(filename string) string {
 		GetLogger().Debugf("checking file extension '%s' for auto format detection", filename)
 		nPos := strings.LastIndex(filename, ".")
 		if nPos > -1 {
-			format := filename[nPos+1:]
+			format := strings.ToLower(filename[nPos+1:])
 			GetLogger().Debugf("detected format '%s'", format)
 			return format
 		}

--- a/pkg/yqlib/format_test.go
+++ b/pkg/yqlib/format_test.go
@@ -50,3 +50,13 @@ func TestFormatFromString(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatStringFromFilename(t *testing.T) {
+	test.AssertResult(t, "yaml", FormatStringFromFilename("test.Yaml"))
+	test.AssertResult(t, "yaml", FormatStringFromFilename("test.index.Yaml"))
+	test.AssertResult(t, "yaml", FormatStringFromFilename("test"))
+	test.AssertResult(t, "json", FormatStringFromFilename("test.json"))
+	test.AssertResult(t, "json", FormatStringFromFilename("TEST.JSON"))
+	test.AssertResult(t, "yaml", FormatStringFromFilename("test.json/foo"))
+	test.AssertResult(t, "yaml", FormatStringFromFilename(""))
+}


### PR DESCRIPTION
To ensure proper file format detection with case-insensitive file systems.
