### PR TITLE
Create kind.md header doc

### DIFF
--- a/pkg/yqlib/doc/operators/headers/kind.md
+++ b/pkg/yqlib/doc/operators/headers/kind.md
@@ -1,0 +1,7 @@
+# Kind
+
+The `kind` operator identifies the type of a node as either `scalar`, `map`, or `seq`.
+
+This can be used for filtering or transforming nodes based on their type.
+
+Note that `null` values are treated as `scalar`.


### PR DESCRIPTION
I noticed that the `kind` operator was the only one that didn't have a header doc. Not that it is in dire _need_ of one... but every other operator has one, so.. 😀

If I understood how all the docs get generated, adding a header doc would need no change to `pkg/yqlib/operator_kind_test.go`.