### PR TITLE
build: use goreleaser for building cross-compiled binaries and add riscv64 target

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,7 +38,7 @@ jobs:
           IMAGE_VERSION=${VERSION:1}
           echo "IMAGE_VERSION: ${IMAGE_VERSION}"
 
-          PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64"
+          PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64,linux/riscv64"
 
           echo "Building and pushing version ${IMAGE_VERSION} of image ${IMAGE_NAME}"
           echo '${{ secrets.DOCKER_PASSWORD }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin
@@ -60,7 +60,7 @@ jobs:
             -t "${IMAGE_NAME}:4" \
             -t "${IMAGE_NAME}:latest" \
             .
-          
+
           cd github-action
           docker buildx build \
             --label "org.opencontainers.image.authors=https://github.com/mikefarah/yq/graphs/contributors" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cross compile
         run: |
           sudo apt-get install rhash -y
-          go install github.com/mitchellh/gox@v1.0.1
+          go install github.com/goreleaser/goreleaser/v2@latest
           mkdir -p build
           cp yq.1 build/yq.1
           ./scripts/xcompile.sh

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,7 @@ builds:
       - linux_mipsle
       - linux_ppc64
       - linux_ppc64le
+      - linux_riscv64
       - linux_s390x
       - netbsd_386
       - netbsd_amd64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,45 @@
+version: 2
+
+dist: build
+
+builds:
+  - id: yq
+
+    binary: yq_{{ .Os }}_{{ .Arch }}
+
+    ldflags:
+      - -s -w
+
+    env:
+      - CGO_ENABLED=0
+
+    targets:
+      - darwin_amd64
+      - darwin_arm64
+      - freebsd_386
+      - freebsd_amd64
+      - freebsd_arm
+      - linux_386
+      - linux_amd64
+      - linux_arm
+      - linux_arm64
+      - linux_mips
+      - linux_mips64
+      - linux_mips64le
+      - linux_mipsle
+      - linux_ppc64
+      - linux_ppc64le
+      - linux_s390x
+      - netbsd_386
+      - netbsd_amd64
+      - netbsd_arm
+      - openbsd_386
+      - openbsd_amd64
+      - windows_386
+      - windows_amd64
+
+    no_unique_dist_dir: true
+
+release:
+  disable: true
+  skip_upload: true

--- a/scripts/xcompile.sh
+++ b/scripts/xcompile.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
-set -e
-# you may need to go install github.com/mitchellh/gox@v1.0.1 first
-echo $VERSION
-CGO_ENABLED=0 gox -ldflags "-s -w ${LDFLAGS}" -output="build/yq_{{.OS}}_{{.Arch}}" --osarch="darwin/amd64 darwin/arm64 freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm linux/arm64 linux/mips linux/mips64 linux/mips64le linux/mipsle linux/ppc64 linux/ppc64le linux/s390x netbsd/386 netbsd/amd64 netbsd/arm openbsd/386 openbsd/amd64 windows/386 windows/amd64"
+
+set -eo pipefail
+
+# You may need to go install github.com/goreleaser/goreleaser/v2@latest first
+GORELEASER="goreleaser build --clean"
+if [ -z "$CI" ]; then
+  GORELEASER+=" --snapshot"
+fi
+
+$GORELEASER
 
 cd build
+
+# Remove artifacts from goreleaser
+rm artifacts.json config.yaml metadata.json
 
 find . -executable -type f | xargs -I {} tar czvf {}.tar.gz {} yq.1 -C ../scripts install-man-page.sh
 tar czvf yq_man_page_only.tar.gz yq.1 -C ../scripts install-man-page.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ architectures:
   - build-on: armhf
   - build-on: amd64
   - build-on: i386
+  - build-on: riscv64
 apps:
   yq:
     command: bin/yq


### PR DESCRIPTION
The main motivation behind it is because "gox" is unmaintained and archived and it does not support "linux/riscv64" as a target.

Right now, goreleaser is only building the binaries, and I've tried to replicate the exact same way the old script does.

In the future, if so desired, goreleaser could be used to further automate the build and release pipeline by creating the release in GitHub.

I've also taken the opportunity in this PR and added `linux/riscv64` as a build target (which closes #1347), but I am happy to move it to another PR as well.