### PR TITLE
chore(build): Update to use go 1.23.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.20'
+        go-version: '^1.23'
+        check-latest: true
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: '^1.23'
           check-latest: true
       - name: Compile man page markup
         id: gen-man-page-md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1 as builder
+FROM golang:1.23.2 as builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.23.1
+FROM golang:1.23.2
 
 RUN apt-get update && \
     apt-get install -y npm && \


### PR DESCRIPTION
## Changes

 - Update the Go version in build and CI to the last version available (1.23)
 - Force to always use the latest version during the testing & release process

Go 1.20 is not maintained anymore (see [here](https://endoflife.date/go) and [here](https://go.dev/doc/devel/release#policy)) and Go 1.23.0 is affected by some CVEs (see the official announcement [here](https://groups.google.com/g/golang-announce/c/K-cEzDeCtpc)).