### PR TITLE
Force no color output if NO_COLOR environment variable is set

### DIFF
--- a/cmd/constant.go
+++ b/cmd/constant.go
@@ -1,5 +1,7 @@
 package cmd
 
+import "os"
+
 var unwrapScalarFlag = newUnwrapFlag()
 
 var unwrapScalar = false
@@ -12,9 +14,6 @@ var outputFormat = ""
 var inputFormat = ""
 
 var exitStatus = false
-var forceColor = false
-var forceNoColor = false
-var colorsEnabled = false
 var indent = 2
 var noDocSeparators = false
 var nullInput = false
@@ -22,6 +21,16 @@ var nulSepOutput = false
 var verbose = false
 var version = false
 var prettyPrint = false
+
+var forceColor = false
+var forceNoColor = false
+var colorsEnabled = false
+
+func init() {
+	// when NO_COLOR environment variable presents and not an empty string the colored output should be disabled;
+	// refer to no-color.org
+	forceNoColor = os.Getenv("NO_COLOR") != ""
+}
 
 // can be either "" (off), "extract" or "process"
 var frontMatter = ""

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,7 +182,7 @@ yq -P -oy sample.json
 	rootCmd.PersistentFlags().BoolVarP(&exitStatus, "exit-status", "e", false, "set exit status if there are no matches or null or false is returned")
 
 	rootCmd.PersistentFlags().BoolVarP(&forceColor, "colors", "C", false, "force print with colors")
-	rootCmd.PersistentFlags().BoolVarP(&forceNoColor, "no-colors", "M", false, "force print with no colors")
+	rootCmd.PersistentFlags().BoolVarP(&forceNoColor, "no-colors", "M", forceNoColor, "force print with no colors")
 	rootCmd.PersistentFlags().StringVarP(&frontMatter, "front-matter", "f", "", "(extract|process) first input as yaml front-matter. Extract will pull out the yaml content, process will run the expression against the yaml content, leaving the remaining data intact")
 	if err = rootCmd.RegisterFlagCompletionFunc("front-matter", cobra.FixedCompletions([]string{"extract", "process"}, cobra.ShellCompDirectiveNoFileComp)); err != nil {
 		panic(err)


### PR DESCRIPTION
Closes #2150 

This PR updates the `cmd` to default to the no colors mode if the `NO_COLOR` environment variable is set. This is to follow the informal standard https://no-color.org/ that states:

> Command-line software which adds ANSI color to its output by default should check for a NO_COLOR environment variable that, when present and not an empty string (regardless of its value), prevents the addition of ANSI color.

Note that the user's CLI flags still override the default behaviour, as per the following:

> User-level configuration files and per-instance command-line arguments should override the NO_COLOR environment variable. A user should be able to export NO_COLOR=1 in their shell configuration file as a default, but configure a specific program in its configuration file to specifically enable color.