### PR TITLE
Create docker image for armv7 / raspberry pi3

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,7 +38,7 @@ jobs:
           IMAGE_VERSION=${VERSION:1}
           echo "IMAGE_VERSION: ${IMAGE_VERSION}"
 
-          PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64"
+          PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64,linux/arm/v7"
 
           echo "Building and pushing version ${IMAGE_VERSION} of image ${IMAGE_NAME}"
           echo '${{ secrets.DOCKER_PASSWORD }}' | docker login -u '${{ secrets.DOCKER_USERNAME }}' --password-stdin


### PR DESCRIPTION
Would be useful to have a docker build for raspberry pi 3

```
$ docker run --rm -v "${PWD}":/workdir mikefarah/yq config.yaml
Unable to find image 'mikefarah/yq:latest' locally
latest: Pulling from mikefarah/yq
docker: no matching manifest for linux/arm/v7 in the manifest list entries.

$ uname -a
Linux garage 5.10.103-v7+ #1529 SMP Tue Mar 8 12:21:37 GMT 2022 armv7l GNU/Linux
```
