### PR TITLE
Install to /usr/local in README install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,21 +76,21 @@ For instance, VERSION=v4.2.0 and BINARY=yq_linux_amd64
 #### Compressed via tar.gz
 ```bash
 wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -O - |\
-  tar xz && mv ${BINARY} /usr/bin/yq
+  tar xz && mv ${BINARY} /usr/local/bin/yq
 ```
 
 #### Plain binary
 
 ```bash
-wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/bin/yq &&\
-    chmod +x /usr/bin/yq
+wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/local/bin/yq &&\
+    chmod +x /usr/loca/bin/yq
 ```
 
 #### Latest version
 
 ```bash
-wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq &&\
-    chmod +x /usr/bin/yq
+wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/loca/bin/yq &&\
+    chmod +x /usr/loca/bin/yq
 ```
 
 ### MacOS / Linux via Homebrew:

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.
 
 ```bash
 wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/local/bin/yq &&\
-    chmod +x /usr/loca/bin/yq
+    chmod +x /usr/local/bin/yq
 ```
 
 #### Latest version
 
 ```bash
-wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/loca/bin/yq &&\
-    chmod +x /usr/loca/bin/yq
+wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq &&\
+    chmod +x /usr/local/bin/yq
 ```
 
 ### MacOS / Linux via Homebrew:


### PR DESCRIPTION
The Linux Filesystem Hierarchy standard stipulate that /usr/bin and /usr/sbin are reserved emplacement for the systems package manager.

The correct emplacement for manually installed software is the directory tree under /usr/local. Therefore, a manually installed yq should go in /usr/local/bin.

(user should then add /usr/local/bin to $PATH)