### PR TITLE
feat: Create parent directories if --split-exp is used.

### DIFF
--- a/acceptance_tests/split-printer.sh
+++ b/acceptance_tests/split-printer.sh
@@ -2,6 +2,7 @@
 
 setUp() {
   rm test*.yml || true
+  rm -rf test_dir* || true
 }
 
 testBasicSplitWithName() {
@@ -202,6 +203,25 @@ name: test_mike
 age: 564
 EOM
   assertEquals "$expectedDoc3" "$doc3"
+}
+
+testSplitWithDirectories() {
+  cat >test.yml <<EOL
+f: test_dir1/file1
+---
+f: test_dir2/dir22/file2
+---
+f: file3
+EOL
+
+  ./yq e --no-doc -s ".f" test.yml
+
+  doc1=$(cat test_dir1/file1.yml)
+  assertEquals "f: test_dir1/file1" "$doc1"
+  doc2=$(cat test_dir2/dir22/file2.yml)
+  assertEquals "f: test_dir2/dir22/file2" "$doc2"
+  doc3=$(cat file3.yml)
+  assertEquals "f: file3" "$doc3"
 }
 
 source ./scripts/shunit2

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -197,7 +197,7 @@ yq -P -oy sample.json
 	}
 	rootCmd.PersistentFlags().BoolVarP(&yqlib.ConfiguredYamlPreferences.LeadingContentPreProcessing, "header-preprocess", "", true, "Slurp any header comments and separators before processing expression.")
 
-	rootCmd.PersistentFlags().StringVarP(&splitFileExp, "split-exp", "s", "", "print each result (or doc) into a file named (exp). [exp] argument must return a string. You can use $index in the expression as the result counter.")
+	rootCmd.PersistentFlags().StringVarP(&splitFileExp, "split-exp", "s", "", "print each result (or doc) into a file named (exp). [exp] argument must return a string. You can use $index in the expression as the result counter. The necessary directories will be created.")
 	if err = rootCmd.RegisterFlagCompletionFunc("split-exp", cobra.NoFileCompletions); err != nil {
 		panic(err)
 	}

--- a/pkg/yqlib/printer_writer.go
+++ b/pkg/yqlib/printer_writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 )
 
@@ -70,6 +71,10 @@ func (sp *multiPrintWriter) GetWriter(node *CandidateNode) (*bufio.Writer, error
 		name = fmt.Sprintf("%v.%v", name, sp.extension)
 	}
 
+	err = os.MkdirAll(filepath.Dir(name), 0750)
+	if err != nil {
+		return nil, err
+	}
 	f, err := os.Create(name)
 
 	if err != nil {


### PR DESCRIPTION
Problem: When --split-exp is used and produces filenames with slashes in them, the target directories must already exist otherwise yq fails.

Fix/feature: Create the necessary directories with os.MkdirAll(). The permissions 0750 were chosen to satisfy the vulnerability checker.