### PR TITLE
Update docs and tests for --properties-separator flag

### DIFF
--- a/pkg/yqlib/doc/usage/properties.md
+++ b/pkg/yqlib/doc/usage/properties.md
@@ -71,7 +71,7 @@ person.food[0] = pizza
 ```
 
 ## Encode properties - custom separator
-Use the --properties-customer-separator flag to specify your own key/value separator.
+Use the --properties-separator flag to specify your own key/value separator.
 
 Given a sample.yml file of:
 ```yaml
@@ -89,7 +89,7 @@ emptyMap: []
 ```
 then
 ```bash
-yq -o=props --properties-customer-separator=" :@ " sample.yml
+yq -o=props --properties-separator=" :@ " sample.yml
 ```
 will output
 ```properties

--- a/pkg/yqlib/properties_test.go
+++ b/pkg/yqlib/properties_test.go
@@ -171,7 +171,7 @@ var propertyScenarios = []formatScenario{
 	},
 	{
 		description:    "Encode properties - custom separator",
-		subdescription: "Use the --properties-customer-separator flag to specify your own key/value separator.",
+		subdescription: "Use the --properties-separator flag to specify your own key/value separator.",
 		input:          samplePropertiesYaml,
 		expected:       expectedPropertiesUnwrappedCustomSeparator,
 		scenarioType:   "encode-custom-separator",
@@ -324,7 +324,7 @@ func documentUnwrappedEncodePropertyScenario(w *bufio.Writer, s formatScenario) 
 		prefs.UseArrayBrackets = true
 	} else if s.scenarioType == "encode-custom-separator" {
 		prefs.KeyValueSeparator = " :@ "
-		useCustomSeparatorFlag = ` --properties-customer-separator=" :@ "`
+		useCustomSeparatorFlag = ` --properties-separator=" :@ "`
 	}
 
 	if expression != "" {


### PR DESCRIPTION
Small update to correct the docs, and tests that generate the docs for the `--properties-separator` flag.  