### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/pkg/yqlib/format.go
+++ b/pkg/yqlib/format.go
@@ -3,6 +3,7 @@ package yqlib
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -95,12 +96,7 @@ func (f *Format) MatchesName(name string) bool {
 	if f.FormalName == name {
 		return true
 	}
-	for _, n := range f.Names {
-		if n == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(f.Names, name)
 }
 
 func (f *Format) GetConfiguredEncoder() Encoder {


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.