### PR TITLE
Typo in cats example

### DIFF
--- a/pkg/yqlib/doc/operators/headers/string-operators.md
+++ b/pkg/yqlib/doc/operators/headers/string-operators.md
@@ -3,7 +3,7 @@
 ## RegEx
 This uses Golang's native regex functions under the hood - See their [docs](https://github.com/google/re2/wiki/Syntax) for the supported syntax.
 
-Case insensitive tip: prefix the regex with `(?i)` - e.g. `test("(?i)cats)"`.
+Case insensitive tip: prefix the regex with `(?i)` - e.g. `test("(?i)cats")`.
 
 ### match(regEx)
 This operator returns the substring match details of the given regEx.


### PR DESCRIPTION
The quotation mark and closing parenthesis were swapped.

Before:
```
$ echo "Hello kitty" | yq eval 'test("(?i)cats)"'
Error: bad expression - probably missing close bracket on TEST
```

After:
```
$ echo "Hello kitty" | yq eval 'test("(?i)cats")'
false
```

I understand this PR could count as a "small change" and may not be merged, per https://github.com/mikefarah/yq/blob/64bee0fbe34e87e4342b92d0fc6a18de27780bd4/CONTRIBUTING.md#how-to-contribute

I'm opening it since it is indeed a typo and the typo is in code at the top of the page.