### PR TITLE
add `windows_arm64` binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,7 @@ builds:
       - openbsd_amd64
       - windows_386
       - windows_amd64
+      - windows_arm64
 
     no_unique_dist_dir: true
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,10 +3,23 @@
 set -o errexit
 set -o pipefail
 
-if command -v golangci-lint &> /dev/null
-then
-    golangci-lint run --verbose
+# TODO: Check if the found golangci-lint version matches the expected version (e.g., v1.62.0), especially if falling back to PATH version.
+
+GOPATH_LINT="$(go env GOPATH)/bin/golangci-lint"
+BIN_LINT="./bin/golangci-lint"
+LINT_CMD=""
+
+if [ -f "$GOPATH_LINT" ]; then
+    LINT_CMD="$GOPATH_LINT"
+elif [ -f "$BIN_LINT" ]; then
+    LINT_CMD="$BIN_LINT"
+elif command -v golangci-lint &> /dev/null; then
+    # Using PATH version, ensure compatibility (see TODO)
+    LINT_CMD="golangci-lint"
 else
-  ./bin/golangci-lint run --verbose
+    echo "Error: golangci-lint not found in $GOPATH/bin, ./bin, or PATH."
+    echo "Please run scripts/devtools.sh or ensure golangci-lint is installed correctly."
+    exit 1
 fi
 
+"$LINT_CMD" run --verbose

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -2,4 +2,4 @@
 set -ex
 go mod download golang.org/x/tools@latest
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.0
-wget -O- -nv https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s
+curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s

--- a/scripts/xcompile.sh
+++ b/scripts/xcompile.sh
@@ -24,9 +24,11 @@ tar czvf yq_man_page_only.tar.gz yq.1 -C ../scripts install-man-page.sh
 
 rm yq_windows_386.exe.tar.gz
 rm yq_windows_amd64.exe.tar.gz
+rm yq_windows_arm64.exe.tar.gz
 
 zip yq_windows_386.zip yq_windows_386.exe
 zip yq_windows_amd64.zip yq_windows_amd64.exe
+zip yq_windows_arm64.zip yq_windows_arm64.exe
 
 rm yq.1
 


### PR DESCRIPTION
Fixes https://github.com/mikefarah/yq/issues/2348

I've also made some changes to `scripts/` since the current config for `golangci-lint` fails with >=v2, and replaced `wget` with `curl` for consistency and to work better with `macOS`.