### PR TITLE
security: update Go version to 1.24.4 to fix CVE-2025-22874

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.20'
+        go-version: '1.24.4'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: '1.24.4'
           check-latest: true
       - name: Compile man page markup
         id: gen-man-page-md

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,4 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 )
 
-go 1.24
-
-toolchain go1.24.1
+go 1.24.4


### PR DESCRIPTION
- Updated go.mod to require Go 1.24.4 (minimum version)
- Updated GitHub workflows to use Go 1.24.4 instead of ^1.20
- Dockerfiles already using Go 1.24.4 (no changes needed)
- Fixes vulnerability CVE-2025-22874 in Go versions < 1.23.10, 1.24.4