### PR TITLE
Build small yq

### DIFF
--- a/pkg/yqlib/candidiate_node_json.go
+++ b/pkg/yqlib/candidiate_node_json.go
@@ -1,3 +1,5 @@
+//go:build !yq_nojson
+
 package yqlib
 
 import (

--- a/pkg/yqlib/decoder_base64.go
+++ b/pkg/yqlib/decoder_base64.go
@@ -1,3 +1,6 @@
+
+//go:build !yq_nobase64
+
 package yqlib
 
 import (

--- a/pkg/yqlib/decoder_csv_object.go
+++ b/pkg/yqlib/decoder_csv_object.go
@@ -1,3 +1,6 @@
+
+//go:build !yq_nocsv
+
 package yqlib
 
 import (

--- a/pkg/yqlib/decoder_properties.go
+++ b/pkg/yqlib/decoder_properties.go
@@ -1,3 +1,5 @@
+//go:build !yq_noprops
+
 package yqlib
 
 import (

--- a/pkg/yqlib/decoder_uri.go
+++ b/pkg/yqlib/decoder_uri.go
@@ -1,3 +1,5 @@
+//go:build !yq_nouri
+
 package yqlib
 
 import (

--- a/pkg/yqlib/encoder_base64.go
+++ b/pkg/yqlib/encoder_base64.go
@@ -1,3 +1,5 @@
+//go:build !yq_nobase64
+
 package yqlib
 
 import (

--- a/pkg/yqlib/encoder_csv.go
+++ b/pkg/yqlib/encoder_csv.go
@@ -1,3 +1,5 @@
+//go:build !yq_nocsv
+
 package yqlib
 
 import (

--- a/pkg/yqlib/encoder_properties.go
+++ b/pkg/yqlib/encoder_properties.go
@@ -1,3 +1,5 @@
+//go:build !yq_noprops
+
 package yqlib
 
 import (

--- a/pkg/yqlib/encoder_sh.go
+++ b/pkg/yqlib/encoder_sh.go
@@ -1,3 +1,5 @@
+//go:build !yq_nosh
+
 package yqlib
 
 import (

--- a/pkg/yqlib/encoder_shellvariables.go
+++ b/pkg/yqlib/encoder_shellvariables.go
@@ -1,3 +1,5 @@
+//go:build !yq_noshell
+
 package yqlib
 
 import (

--- a/pkg/yqlib/encoder_uri.go
+++ b/pkg/yqlib/encoder_uri.go
@@ -1,3 +1,5 @@
+//go:build !yq_nouri
+
 package yqlib
 
 import (

--- a/pkg/yqlib/no_base64.go
+++ b/pkg/yqlib/no_base64.go
@@ -1,0 +1,11 @@
+//go:build yq_nobase64
+
+package yqlib
+
+func NewBase64Decoder() Decoder {
+	return nil
+}
+
+func NewBase64Encoder() Encoder {
+	return nil
+}

--- a/pkg/yqlib/no_csv.go
+++ b/pkg/yqlib/no_csv.go
@@ -1,0 +1,11 @@
+//go:build yq_nocsv
+
+package yqlib
+
+func NewCSVObjectDecoder(prefs CsvPreferences) Decoder {
+	return nil
+}
+
+func NewCsvEncoder(prefs CsvPreferences) Encoder {
+	return nil
+}

--- a/pkg/yqlib/no_ini.go
+++ b/pkg/yqlib/no_ini.go
@@ -6,6 +6,6 @@ func NewINIDecoder() Decoder {
 	return nil
 }
 
-func NewINIEncoder(indent int) Encoder {
+func NewINIEncoder() Encoder {
 	return nil
 }

--- a/pkg/yqlib/no_json.go
+++ b/pkg/yqlib/no_json.go
@@ -6,6 +6,6 @@ func NewJSONDecoder() Decoder {
 	return nil
 }
 
-func NewJSONEncoder(indent int, colorise bool, unwrapScalar bool) Encoder {
+func NewJSONEncoder(prefs JsonPreferences) Encoder {
 	return nil
 }

--- a/pkg/yqlib/no_props.go
+++ b/pkg/yqlib/no_props.go
@@ -1,0 +1,11 @@
+//go:build yq_noprops
+
+package yqlib
+
+func NewPropertiesDecoder() Decoder {
+	return nil
+}
+
+func NewPropertiesEncoder(prefs PropertiesPreferences) Encoder {
+	return nil
+}

--- a/pkg/yqlib/no_sh.go
+++ b/pkg/yqlib/no_sh.go
@@ -1,0 +1,7 @@
+//go:build yq_nosh
+
+package yqlib
+
+func NewShEncoder() Encoder {
+	return nil
+}

--- a/pkg/yqlib/no_shellvariables.go
+++ b/pkg/yqlib/no_shellvariables.go
@@ -1,0 +1,7 @@
+//go:build yq_noshell
+
+package yqlib
+
+func NewShellVariablesEncoder() Encoder {
+	return nil
+}

--- a/pkg/yqlib/no_uri.go
+++ b/pkg/yqlib/no_uri.go
@@ -1,0 +1,11 @@
+//go:build yq_nouri
+
+package yqlib
+
+func NewUriDecoder() Decoder {
+	return nil
+}
+
+func NewUriEncoder() Encoder {
+	return nil
+}

--- a/pkg/yqlib/no_xml.go
+++ b/pkg/yqlib/no_xml.go
@@ -6,6 +6,6 @@ func NewXMLDecoder(prefs XmlPreferences) Decoder {
 	return nil
 }
 
-func NewXMLEncoder(indent int, prefs XmlPreferences) Encoder {
+func NewXMLEncoder(prefs XmlPreferences) Encoder {
 	return nil
 }

--- a/project-words.txt
+++ b/project-words.txt
@@ -258,3 +258,9 @@ nolint
 shortfile
 Unmarshalling
 noini
+nocsv
+nobase64
+nouri
+noprops
+nosh
+noshell

--- a/scripts/build-small-yq.sh
+++ b/scripts/build-small-yq.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-go build -tags "yq_nolua yq_notoml yq_noxml yq_nojson" -ldflags "-s -w" .
+go build -tags "yq_nolua yq_noini yq_notoml yq_noxml yq_nojson" -ldflags "-s -w" .

--- a/scripts/build-tinygo-yq.sh
+++ b/scripts/build-tinygo-yq.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Currently, the `yq_nojson` feature must be enabled when using TinyGo.
+tinygo build -no-debug -tags "yq_nolua yq_noini yq_notoml yq_noxml yq_nojson" .

--- a/scripts/build-tinygo-yq.sh
+++ b/scripts/build-tinygo-yq.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Currently, the `yq_nojson` feature must be enabled when using TinyGo.
-tinygo build -no-debug -tags "yq_nolua yq_noini yq_notoml yq_noxml yq_nojson" .
+tinygo build -no-debug -tags "yq_nolua yq_noini yq_notoml yq_noxml yq_nojson yq_nocsv yq_nobase64 yq_nouri yq_noprops yq_nosh yq_noshell" .


### PR DESCRIPTION
1. Fix compilation errors when building `build-small-yq`
2. Add `yq_noini` tag to `build-small-yq`
3. Add TinyGo build example 