### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Using [Homebrew](https://brew.sh/)
 brew install yq
 ```
 
+### MacOS / Linux via gah:
+Using [gah](https://github.com/marverix/gah)
+```
+gah install yq
+```
+
 ### Linux via snap:
 ```
 snap install yq


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.