### PR TITLE
Use ghcr.io instead of ghrc.io

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -95,6 +95,6 @@ jobs:
             -t "${IMAGE_NAME}:4-githubaction" \
             -t "${IMAGE_NAME}:latest-githubaction" \
             -t "ghcr.io/${IMAGE_NAME}:${IMAGE_VERSION}-githubaction" \
-            -t "ghrc.io/${IMAGE_NAME}:4-githubaction" \
+            -t "ghcr.io/${IMAGE_NAME}:4-githubaction" \
             -t "ghcr.io/${IMAGE_NAME}:latest-githubaction" \
             .


### PR DESCRIPTION
Fix typo that points to the wrong registry.

Fixes: #2451 