### PR TITLE
Github Action to auto push new releases to Winget package registry

### DIFF
--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -1,0 +1,16 @@
+name: Publish release to WinGet
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: MikeFarah.yq
+          installers-regex: 'yq_windows_amd64\.exe$'
+          version: ${{ github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Note, in the meantime, I've created a cron running every night via a [github action](https://github.com/jo-chemla/winget-pkgs/blob/auto-winget-updater/.github/workflows/auto-winget-updater.yml) that pushes new yq github releases to winget registry as soon as they are detected. Since it would be preferable to have the official yq package published to winget via a repo workflow, the below github action does this. 

Uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) Requires a `Classic Github Personal Access Token` with `public_repo` scope is created, following [this link](https://github.com/settings/tokens/new), then the Token can be added to the repo as a secret named `WINGET_ACC_TOKEN`. See below, that user also will have to fork the winget-pkgs repository.

> Notes:
> You will need to create a *classic* Personal Access Token (PAT) with `public_repo` scope. New fine-grained PATs aren't supported by the action. Review #172 for information.
> Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account/organization as the project's repository. If you are forking winget-pkgs on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.
