### PR TITLE
Add version information to fix-merge-anchor option

### DIFF
--- a/operators/traverse-read.md
+++ b/operators/traverse-read.md
@@ -3,7 +3,7 @@
 This is the simplest (and perhaps most used) operator. It is used to navigate deeply into yaml structures.
 
 
-## NOTE --yaml-fix-merge-anchor-to-spec flag
+## NOTE --yaml-fix-merge-anchor-to-spec flag (v4.47.1 [#2110](https://github.com/mikefarah/yq/issues/2110))
 `yq` doesn't merge anchors `<<:` to spec, in some circumstances it incorrectly overrides existing keys when the spec documents not to do that.
 
 To minimise disruption while still fixing the issue, a flag has been added to toggle this behaviour. This will first default to false; and log warnings to users. Then it will default to true (and still allow users to specify false if needed)


### PR DESCRIPTION
It was a little bit confusing since documentation version only refers to `v4.x` and my version did not have this option