### PR TITLE
fix: keep xml namespace prefixes for tags 

### DIFF
--- a/pkg/yqlib/decoder_xml.go
+++ b/pkg/yqlib/decoder_xml.go
@@ -270,10 +270,16 @@ func (dec *xmlDecoder) decodeXML(root *xmlNode) error {
 			log.Debug("start element %v", se.Name.Local)
 			elem.state = "started"
 			// Build new a new current element and link it to its parent
+			var label = se.Name.Local
+			if dec.prefs.KeepNamespace {
+				if se.Name.Space != "" {
+					label = se.Name.Space + ":" + se.Name.Local
+				}
+			}
 			elem = &element{
 				parent: elem,
 				n:      &xmlNode{},
-				label:  se.Name.Local,
+				label:  label,
 			}
 
 			// Extract attributes as children

--- a/pkg/yqlib/doc/usage/xml.md
+++ b/pkg/yqlib/doc/usage/xml.md
@@ -343,7 +343,7 @@ instead of
 <?xml version="1.0"?>
 <map xmlns="some-namespace" xmlns:xsi="some-instance" xsi:schemaLocation="some-url">
   <item foo="bar">baz</item>
-  <item>foobar</item>
+  <xsi:item>foobar</xsi:item>
 </map>
 ```
 
@@ -366,10 +366,10 @@ yq --xml-raw-token=false '.' sample.xml
 will output
 ```xml
 <?xml version="1.0"?>
-<map xmlns="some-namespace" xmlns:xsi="some-instance" some-instance:schemaLocation="some-url">
-  <item foo="bar">baz</item>
-  <item>foobar</item>
-</map>
+<some-namespace:map xmlns="some-namespace" xmlns:xsi="some-instance" some-instance:schemaLocation="some-url">
+  <some-namespace:item foo="bar">baz</some-namespace:item>
+  <some-instance:item>foobar</some-instance:item>
+</some-namespace:map>
 ```
 
 instead of
@@ -377,7 +377,7 @@ instead of
 <?xml version="1.0"?>
 <map xmlns="some-namespace" xmlns:xsi="some-instance" xsi:schemaLocation="some-url">
   <item foo="bar">baz</item>
-  <item>foobar</item>
+  <xsi:item>foobar</xsi:item>
 </map>
 ```
 

--- a/pkg/yqlib/xml_test.go
+++ b/pkg/yqlib/xml_test.go
@@ -200,9 +200,9 @@ map:
   +@xmlns:xsi: some-instance
   +@xsi:schemaLocation: some-url
   item:
-    - +content: baz
-      +@foo: bar
-    - foobar
+    +content: baz
+    +@foo: bar
+  xsi:item: foobar
 `
 
 const expectedYAMLWithRawNamespacedAttr = `+p_xml: version="1.0"
@@ -211,20 +211,20 @@ map:
   +@xmlns:xsi: some-instance
   +@xsi:schemaLocation: some-url
   item:
-    - +content: baz
-      +@foo: bar
-    - foobar
+    +content: baz
+    +@foo: bar
+  xsi:item: foobar
 `
 
 const expectedYAMLWithoutRawNamespacedAttr = `+p_xml: version="1.0"
-map:
+some-namespace:map:
   +@xmlns: some-namespace
   +@xmlns:xsi: some-instance
   +@some-instance:schemaLocation: some-url
-  item:
-    - +content: baz
-      +@foo: bar
-    - foobar
+  some-namespace:item:
+    +content: baz
+    +@foo: bar
+  some-instance:item: foobar
 `
 
 const xmlWithCustomDtd = `


### PR DESCRIPTION
fixes `--xml-keep-namespace=true` so that element tags keep their namespace prefix. e.g. 

```xml
<xsi:foo>bar</xsi:foo>
```

does a roundtrip unchanged (rather than becoming `<foo>bar</foo>`)


fixes #1730