### PR TITLE
Update architechtures

### DIFF
--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -15,6 +15,10 @@ jobs:
         - uses: actions/checkout@v5
         - uses: snapcore/action-build@v1
           id: build
+          env:
+            SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+          with:
+            snapcraft-args: "remote-build"
         - uses: snapcore/action-publish@v1
           env:
             SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,13 +13,11 @@ architectures:
     build-for: [arm64]
   - build-on: [armhf]
     build-for: [armhf]
-  - build-on: [i386]
-    build-for: [i386]
   - build-on: [ppc64el]
     build-for: [ppc64el]
   - build-on: [s390x]
     build-for: [s390x]
-  - build-on: [amd64]
+  - build-on: [riscv64]
     build-for: [riscv64]
 apps:
   yq:


### PR DESCRIPTION
**What this PR does**
Remote build snap builds to use native build-on per architecture so each snap is compiled on the correct platform.
Fixes misbuilt arm snaps that were produced on amd64 and failed with exec format errors on arm devices.
Build using launchpad remote builder instead of the github action worker.

**Why**
Snapcraft’s Go plugin doesn’t cross-compile; building arm snaps on amd64 produced amd64 binaries mislabeled as arm, breaking installs on arm. Using native builders per arch restores correct binaries for arm64/armhf (and others).