### PR TITLE
Bumped to core24 and removed riscv64

### DIFF
--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -18,7 +18,7 @@ jobs:
           env:
             SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
           with:
-            snapcraft-args: "remote-build"
+            snapcraft-args: "remote-build --launchpad-accept-public-upload"
         - uses: snapcore/action-publish@v1
           env:
             SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,22 +3,26 @@ version: 'v4.49.2'
 summary: A lightweight and portable command-line data file processor
 description: |
   `yq` uses [jq](https://github.com/stedolan/jq) like syntax but works with yaml, json, xml, csv, properties and TOML files.
-base: core22
+base: core24
 grade: stable # devel|stable. must be 'stable' to release into candidate/stable channels
 confinement: strict
-architectures:
-  - build-on: [amd64]
+platforms:
+  amd64:
+    build-on: [amd64]
     build-for: [amd64]
-  - build-on: [arm64]
+  arm64:
+    build-on: [arm64]
     build-for: [arm64]
-  - build-on: [armhf]
+  armhf:
+    build-on: [armhf]
     build-for: [armhf]
-  - build-on: [ppc64el]
-    build-for: [ppc64el]
-  - build-on: [s390x]
+  s390x:
+    build-on: [s390x]
     build-for: [s390x]
-  - build-on: [riscv64]
-    build-for: [riscv64]
+  ppc64el:
+    build-on: [ppc64el]
+    build-for: [ppc64el]
+    
 apps:
   yq:
     command: bin/yq


### PR DESCRIPTION
- riscv64 was timing out, and was removed from snap builds.
- Non-interactive flag added for remote builds
- bumped snap base to core 24