### PR TITLE
upgrade go version to 1.25.5 and to build yq on ppc64le

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.20'
+        go-version: '1.25.5'
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: '1.25.5'
           check-latest: true
       - name: Compile man page markup
         id: gen-man-page-md

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,4 @@ require (
 	golang.org/x/tools v0.38.0 // indirect
 )
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.5

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 set -ex
 go mod download golang.org/x/tools@latest
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.5
-curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.22.5
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.6.1
+arch="$(uname -m)"
+if [ "$arch" = "ppc64le" ]; then
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+else
+	curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s
+fi


### PR DESCRIPTION
issue - [#2540](https://github.com/mikefarah/yq/issues/2540)

The PR is to resolve the following issues: 
- to resolve CVEs like [CVE-2025-61727](https://github.com/advisories/GHSA-5mh9-3jwc-rp59) and [CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2) by upgrading go version 
-  to build yq in ppc64le