### PR TITLE
Fix default command used for __completeNoDesc alias

### DIFF
--- a/yq.go
+++ b/yq.go
@@ -12,7 +12,7 @@ func main() {
 	args := os.Args[1:]
 
 	_, _, err := cmd.Find(args)
-	if err != nil && args[0] != "__complete" {
+	if err != nil && args[0] != "__complete" && args[0] != "__completeNoDesc" {
 		// default command when nothing matches...
 		newArgs := []string{"eval"}
 		cmd.SetArgs(append(newArgs, os.Args[1:]...))

--- a/yq_test.go
+++ b/yq_test.go
@@ -48,6 +48,12 @@ func TestMainFunctionLogic(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error when no command found for '__complete', but got nil")
 	}
+
+	args = []string{"__completeNoDesc"}
+	_, _, err = cmd.Find(args)
+	if err == nil {
+		t.Error("Expected error when no command found for '__completeNoDesc', but got nil")
+	}
 }
 
 func TestMainFunctionWithArgs(t *testing.T) {
@@ -74,6 +80,12 @@ func TestMainFunctionWithArgs(t *testing.T) {
 	_, _, err = cmd.Find(args)
 	if err == nil {
 		t.Error("Expected error with __complete command")
+	}
+
+	args = []string{"__completeNoDesc"}
+	_, _, err = cmd.Find(args)
+	if err == nil {
+		t.Error("Expected error with __completeNoDesc command")
 	}
 }
 
@@ -148,6 +160,28 @@ func TestMainFunctionWithCompletionCommand(t *testing.T) {
 	if args[0] == "__complete" {
 		// This means the default command logic should NOT execute
 		t.Log("__complete command correctly identified, default command logic should not execute")
+	}
+}
+
+func TestMainFunctionWithCompletionNoDescCommand(t *testing.T) {
+	// Test that __complete command doesn't trigger default command logic
+	cmd := command.New()
+
+	args := []string{"__completeNoDesc"}
+	_, _, err := cmd.Find(args)
+	if err == nil {
+		t.Error("Expected error with __completeNoDesc command")
+	}
+
+	// The main function logic would be:
+	// if err != nil && args[0] != "__completeNoDesc" {
+	//     // This should NOT execute for __completeNoDesc
+	// }
+
+	// Verify that __completeNoDesc doesn't trigger the default command logic
+	if args[0] == "__completeNoDesc" {
+		// This means the default command logic should NOT execute
+		t.Log("__completeNoDesc command correctly identified, default command logic should not execute")
 	}
 }
 


### PR DESCRIPTION
Fixes: #2482

`__completeNoDesc` is an alias for `__complete`

https://github.com/spf13/cobra/blob/6dec1ae26659a130bdb4c985768d1853b0e1bc06/completions.go#L234

It is used for Powershell tab-completion

```
yq completion powershell | grep '__completeNoDesc'
    $RequestComp="$Program __completeNoDesc $Arguments"
```

before:

```
yq __completeNoDesc --pretty
Error: unknown flag: --pretty
Usage:
  yq eval [expression] [yaml_file1]... [flags]

Aliases:
  eval, e
...
```

after:

```
yq __completeNoDesc --pretty
--prettyPrint
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```