### PR TITLE
Revise deprecated bash completion instructions for Linux

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -18,7 +18,7 @@ $ source <(yq completion bash)
 
 # To load completions for each session, execute once:
 Linux:
-  $ yq completion bash > /etc/bash_completion.d/yq
+  $ yq completion bash > /usr/share/bash-completion/completions/yq
 MacOS:
   $ yq completion bash > /usr/local/etc/bash_completion.d/yq
 


### PR DESCRIPTION
As per [the FAQ](https://github.com/scop/bash-completion#faq), I revised the instructions for bash completions on Linux, as `/etc/bash_completion.d` has been considered deprecated for a number of years and it's usage is not recommended by the upstream. I didn't change the Mac instruction line, because I do not own a Mac and cannot verify that.

All that being said; According to the FAQ the best way to actually get the path to the completions directory is to use `pkg-config --variable completionsdir bash-completion`, though I can't say with any certainty how many users may have have the pkg-config file for bash-completion installed, that might be something distributions like Fedora and Debian would have in a `-dev/-devel` package. The instructions for a normal user to install them locally are to put them in `$XDG_DATA_HOME` (default `~/.local/share`) in a subdirectory `bash-completion/completions/<name>`, but I guess that would be something at your discretion (maybe a bit too wordy, etc). But if you do want to use the user-level instructions (which should be portable to Macos, as long as `$HOME` exists), here is a simple one-line shell command for that, using install since it will create the parent directories:
```bash
# Linux
yq completion bash | install -Dm 0644 /dev/stdin ~/.local/share/bash-completion/completions/yq
# Mac
mkdir -p ~/.local/share/bash-completion/completions && yq completion bash > ~/.local/share/bash-completion/completions/yq
```