### PR TITLE
buildfix: which -> command -v

### DIFF
--- a/Makefile.variables
+++ b/Makefile.variables
@@ -27,7 +27,8 @@ ifeq ($(CYG_CHECK),1)
 else
 	# all non-windows environments
 	ROOT := $(shell pwd)
-	SELINUX := $(shell which getenforce 2>&1 >/dev/null && echo :z)
+	# Deliberately use `command -v` instead of `which` to be POSIX compliant
+	SELINUX := $(shell command -v getenforce >/dev/null 2>&1 && echo :z)
 endif
 
 DEV_IMAGE := ${PROJECT}_dev


### PR DESCRIPTION
It didn't build on my CachyOS host due to different behavior of `which`. `command -v` is a POSIX standard and hopefully
more compatible.

Fixes:
```
error:
/usr/bin/docker run --rm -e LDFLAGS="-X main.GitCommit=5f90039b -X main.GitDescribe=v4-45-g5f90039b -w -s" -e GOFLAGS="" -e GITHUB_TOKEN="" -v /home/sydarn/git/yq/vendor:/go/srcwhich: no getenforce in (/usr/local/bin:/usr/bin) -v /home/sydarn/git/yq:/yq/src/github.com/mikefarah/yqwhich: no getenforce in (/usr/local/bin:/usr/bin) -w /yq/src/github.com/mikefarah/yq yq_dev go mod vendor
/bin/bash: -c: line 1: syntax error near unexpected token `('
```