### PR TITLE
feat: Add --yaml-compact-seq-indent / -c flag for compact sequence indentation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,6 +203,7 @@ yq -P -oy sample.json
 	}
 	rootCmd.PersistentFlags().BoolVarP(&yqlib.ConfiguredYamlPreferences.LeadingContentPreProcessing, "header-preprocess", "", true, "Slurp any header comments and separators before processing expression.")
 	rootCmd.PersistentFlags().BoolVarP(&yqlib.ConfiguredYamlPreferences.FixMergeAnchorToSpec, "yaml-fix-merge-anchor-to-spec", "", false, "Fix merge anchor to match YAML spec. Will default to true in late 2025")
+	rootCmd.PersistentFlags().BoolVarP(&yqlib.ConfiguredYamlPreferences.CompactSequenceIndent, "yaml-compact-seq-indent", "c", false, "Use compact sequence indentation where '- ' is considered part of the indentation.")
 
 	rootCmd.PersistentFlags().StringVarP(&splitFileExp, "split-exp", "s", "", "print each result (or doc) into a file named (exp). [exp] argument must return a string. You can use $index in the expression as the result counter. The necessary directories will be created.")
 	if err = rootCmd.RegisterFlagCompletionFunc("split-exp", cobra.NoFileCompletions); err != nil {

--- a/pkg/yqlib/encoder_yaml.go
+++ b/pkg/yqlib/encoder_yaml.go
@@ -52,6 +52,9 @@ func (ye *yamlEncoder) Encode(writer io.Writer, node *CandidateNode) error {
 	var encoder = yaml.NewEncoder(destination)
 
 	encoder.SetIndent(ye.prefs.Indent)
+	if ye.prefs.CompactSequenceIndent {
+		encoder.CompactSeqIndent()
+	}
 
 	target, err := node.MarshalYAML()
 

--- a/pkg/yqlib/yaml.go
+++ b/pkg/yqlib/yaml.go
@@ -8,6 +8,7 @@ type YamlPreferences struct {
 	UnwrapScalar                bool
 	EvaluateTogether            bool
 	FixMergeAnchorToSpec        bool
+	CompactSequenceIndent       bool
 }
 
 func NewDefaultYamlPreferences() YamlPreferences {
@@ -19,6 +20,7 @@ func NewDefaultYamlPreferences() YamlPreferences {
 		UnwrapScalar:                true,
 		EvaluateTogether:            false,
 		FixMergeAnchorToSpec:        false,
+		CompactSequenceIndent:       false,
 	}
 }
 
@@ -31,6 +33,7 @@ func (p *YamlPreferences) Copy() YamlPreferences {
 		UnwrapScalar:                p.UnwrapScalar,
 		EvaluateTogether:            p.EvaluateTogether,
 		FixMergeAnchorToSpec:        p.FixMergeAnchorToSpec,
+		CompactSequenceIndent:       p.CompactSequenceIndent,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a new CLI flag `--yaml-compact-seq-indent` (shortcut `-c`) that enables compact sequence indentation
- When enabled, `'- '` is considered part of the indentation, resulting in sequences that align with their parent key
- Leverages the `CompactSeqIndent()` method from the underlying `go.yaml.in/yaml/v4` library

## Example

**Default behavior:**
```yaml
parent:
  items:
    - one
    - two
```

**With `--yaml-compact-seq-indent` / `-c`:**
```yaml
parent:
  items:
  - one
  - two
```

## Test plan

- [x] Verified build compiles successfully
- [x] Tested flag works with both long and short forms
- [x] Verified default behavior is unchanged (sequences remain indented)
- [ ] Run full test suite

Closes #1841