### PR TITLE
fixes #2623: upgrade go to 1.24.1 to fix CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,6 @@ require (
 	golang.org/x/tools v0.41.0 // indirect
 )
 
-go 1.24.0
+go 1.24.1
 
 toolchain go1.24.1


### PR DESCRIPTION
Disclaimer: I'm not fully confident that this is all that's required, as I'm not familiar with this repo.