### PR TITLE
Add Kind assertions to findInArray and findKeyInMap

### DIFF
--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -52,7 +52,9 @@ func recurseNodeArrayEqual(lhs *CandidateNode, rhs *CandidateNode) bool {
 }
 
 func findInArray(array *CandidateNode, item *CandidateNode) int {
-
+	if array.Kind != SequenceNode {
+		panic(fmt.Sprintf("findInArray called on %v node, expected SequenceNode", array.Tag))
+	}
 	for index := 0; index < len(array.Content); index = index + 1 {
 		if recursiveNodeEqual(array.Content[index], item) {
 			return index
@@ -62,7 +64,9 @@ func findInArray(array *CandidateNode, item *CandidateNode) int {
 }
 
 func findKeyInMap(dataMap *CandidateNode, item *CandidateNode) int {
-
+	if dataMap.Kind != MappingNode {
+		panic(fmt.Sprintf("findKeyInMap called on %v node, expected MappingNode", dataMap.Tag))
+	}
 	for index := 0; index < len(dataMap.Content); index = index + 2 {
 		if recursiveNodeEqual(dataMap.Content[index], item) {
 			return index

--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -52,7 +52,10 @@ func recurseNodeArrayEqual(lhs *CandidateNode, rhs *CandidateNode) bool {
 }
 
 func findInArray(array *CandidateNode, item *CandidateNode) int {
-
+	if array.Kind != SequenceNode {
+		log.Warningf("findInArray called on %v node, expected SequenceNode", array.Tag)
+		return -1
+	}
 	for index := 0; index < len(array.Content); index = index + 1 {
 		if recursiveNodeEqual(array.Content[index], item) {
 			return index
@@ -62,7 +65,10 @@ func findInArray(array *CandidateNode, item *CandidateNode) int {
 }
 
 func findKeyInMap(dataMap *CandidateNode, item *CandidateNode) int {
-
+	if dataMap.Kind != MappingNode {
+		log.Warningf("findKeyInMap called on %v node, expected MappingNode", dataMap.Tag)
+		return -1
+	}
 	for index := 0; index < len(dataMap.Content); index = index + 2 {
 		if recursiveNodeEqual(dataMap.Content[index], item) {
 			return index


### PR DESCRIPTION
`findInArray` and `findKeyInMap` accept any `*CandidateNode` but produce wrong results when called on the wrong `Kind`: `findInArray` uses stride 1, correct for `SequenceNodes` but dangerous on `MappingNodes` (where key-value pairs live at even-odd indices); `findKeyInMap` uses stride 2, correct for `MappingNodes` but silently skips elements in `SequenceNodes`.

Commit b0ba9589 fixed two call sites that passed `MappingNodes` to `findInArray`, but nothing prevents the same mistake from recurring. These assertions make both functions panic immediately on a `Kind` mismatch, catching misuse in tests rather than producing silent data corruption.

I was tempted to rename `findInArray` to `findInSequence` to match `SequenceNode`, but didn't want to engage in gratuitous refactoring. But still may be worth harmonizing the terminology.