### PR TITLE
fix: array traversal drops streaming indices from variable binding

### DIFF
--- a/pkg/yqlib/operator_traverse_path.go
+++ b/pkg/yqlib/operator_traverse_path.go
@@ -123,6 +123,27 @@ func traverseArrayOperator(d *dataTreeNavigator, context Context, expressionNode
 	if expressionNode.Operation.Preferences != nil {
 		prefs = expressionNode.Operation.Preferences.(traversePreferences)
 	}
+
+	// When streaming values produce per-value index sets in the RHS and the LHS
+	// is a single node (e.g. a bound variable), traverse the LHS with each
+	// index set separately. Without this, only the first set of indices is used
+	// and the rest are silently dropped.
+	if rhs.MatchingNodes.Len() > 1 && lhs.MatchingNodes.Len() < rhs.MatchingNodes.Len() {
+		var allResults = list.New()
+		for el := rhs.MatchingNodes.Front(); el != nil; el = el.Next() {
+			seqNode := el.Value.(*CandidateNode)
+			if seqNode.Kind != SequenceNode {
+				continue
+			}
+			result, err := traverseNodesWithArrayIndices(lhs, seqNode.Content, prefs)
+			if err != nil {
+				return Context{}, err
+			}
+			allResults.PushBackList(result.MatchingNodes)
+		}
+		return context.ChildContext(allResults), nil
+	}
+
 	var indicesToTraverse = rhs.MatchingNodes.Front().Value.(*CandidateNode).Content
 
 	log.Debugf("indicesToTraverse %v", len(indicesToTraverse))

--- a/pkg/yqlib/operator_traverse_path_test.go
+++ b/pkg/yqlib/operator_traverse_path_test.go
@@ -134,6 +134,38 @@ var badTraversePathOperatorScenarios = []expressionScenario{
 var traversePathOperatorScenarios = []expressionScenario{
 	{
 		skipDoc:     true,
+		description: "traverse array with streaming indices from keys",
+		document:    `["a","b"]`,
+		expression:  `. as $o | keys[] | $o[.]`,
+		expected: []string{
+			"D0, P[0], (!!str)::a\n",
+			"D0, P[1], (!!str)::b\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "traverse map with streaming indices from keys",
+		document:    `{x: "a", y: "b"}`,
+		expression:  `. as $o | keys[] | $o[.]`,
+		expected: []string{
+			"D0, P[x], (!!str)::a\n",
+			"D0, P[y], (!!str)::b\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "traverse longer array with streaming indices from keys",
+		document:    `["a","b","c","d"]`,
+		expression:  `. as $o | keys[] | $o[.]`,
+		expected: []string{
+			"D0, P[0], (!!str)::a\n",
+			"D0, P[1], (!!str)::b\n",
+			"D0, P[2], (!!str)::c\n",
+			"D0, P[3], (!!str)::d\n",
+		},
+	},
+	{
+		skipDoc:     true,
 		description: "strange map with key but no value",
 		document:    "!!null\n-",
 		expression:  ".x",


### PR DESCRIPTION
Fixes #2593

## Problem

When streaming values pipe into an array traversal with a bound variable, only the first index is used. For example:

```bash
$ echo '["a","b"]' | yq '. as $o | keys[] | $o[.]'
a
# expected: a, b
```

The workaround of adding an intermediate variable binding (`. as $k |`) works, but shouldn't be necessary:

```bash
$ echo '["a","b"]' | yq '. as $o | keys[] | . as $k | $o[.]'
a
b
```

## Root cause

In `traverseArrayOperator`, the RHS collect expression is evaluated with the full streaming context. When `EvaluateTogether` is false (the default for streaming values), the collect operator creates a separate SequenceNode per streaming value. Line 126 then only takes the first SequenceNode's content, discarding the indices from all other streaming values.

## Fix

When the RHS produces more SequenceNodes than the LHS has matching nodes (i.e., the LHS is a single bound variable but the index varies per streaming value), traverse each set of indices separately against the full LHS.

## Before/After

```bash
# Before
$ echo '["a","b"]' | yq '. as $o | keys[] | $o[.]'
a

# After
$ echo '["a","b"]' | yq '. as $o | keys[] | $o[.]'
a
b
```

Works for both arrays and maps:
```bash
$ echo '{"x":"a","y":"b"}' | yq '. as $o | keys[] | $o[.]'
a
b
```

## Testing

Added three regression tests covering arrays, maps, and longer sequences. Full test suite passes:

```
ok  github.com/mikefarah/yq/v4          0.353s
ok  github.com/mikefarah/yq/v4/cmd      0.447s
ok  github.com/mikefarah/yq/v4/pkg/yqlib 0.491s
ok  github.com/mikefarah/yq/v4/test     0.468s
```