### PR TITLE
Quote top-level string scalars whose bare form re-parses as a container

### DIFF
--- a/pkg/yqlib/base64_test.go
+++ b/pkg/yqlib/base64_test.go
@@ -81,10 +81,13 @@ var base64Scenarios = []formatScenario{
 		scenarioType: "decode",
 	},
 	{
-		skipDoc:      true,
-		description:  "decode yaml document",
-		input:        base64EncodedYaml,
-		expected:     base64DecodedYaml + "\n",
+		skipDoc:     true,
+		description: "decode yaml document",
+		input:       base64EncodedYaml,
+		// The decoded payload ("a: apple\n") would re-parse as a map if
+		// emitted bare, so the yaml encoder keeps it as a block literal to
+		// preserve roundtrip safety. See issue #2608.
+		expected:     "|\n    a: apple\n",
 		scenarioType: "decode",
 	},
 	{

--- a/pkg/yqlib/encoder_yaml.go
+++ b/pkg/yqlib/encoder_yaml.go
@@ -35,7 +35,7 @@ func (ye *yamlEncoder) Encode(writer io.Writer, node *CandidateNode) error {
 	if strings.Contains(node.LeadingContent, "\r\n") {
 		lineEnding = "\r\n"
 	}
-	if node.Kind == ScalarNode && ye.prefs.UnwrapScalar {
+	if node.Kind == ScalarNode && ye.prefs.UnwrapScalar && !bareStringNeedsQuoting(node) {
 		valueToPrint := node.Value
 		if node.LeadingContent == "" || valueToPrint != "" {
 			valueToPrint = valueToPrint + lineEnding
@@ -77,4 +77,29 @@ func (ye *yamlEncoder) Encode(writer io.Writer, node *CandidateNode) error {
 		return colorizeAndPrint(tempBuffer.Bytes(), writer)
 	}
 	return nil
+}
+
+// bareStringNeedsQuoting reports whether a top-level string scalar would be
+// structurally reinterpreted if emitted as an unquoted bare value. The
+// unwrap-scalar fast-path writes node.Value verbatim, which silently turns a
+// string like "this: should really work" into a mapping on the next read, or
+// "- item" into a sequence. When this returns true the caller falls through
+// to the full yaml encoder, which applies the quoting style required by the
+// YAML spec. Scalar-to-scalar reinterpretations (e.g. "123" parsing as an int
+// tag) are not covered here: they preserve the node shape and are handled by
+// callers that care about explicit tag preservation.
+func bareStringNeedsQuoting(node *CandidateNode) bool {
+	if node.Tag != "!!str" {
+		return false
+	}
+	var parsed yaml.Node
+	if err := yaml.Unmarshal([]byte(node.Value), &parsed); err != nil {
+		// Unparseable bare form (e.g. control characters): leave it on the
+		// fast-path so callers that check for those characters still see them.
+		return false
+	}
+	if parsed.Kind != yaml.DocumentNode || len(parsed.Content) != 1 {
+		return false
+	}
+	return parsed.Content[0].Kind != yaml.ScalarNode
 }

--- a/pkg/yqlib/encoder_yaml_test.go
+++ b/pkg/yqlib/encoder_yaml_test.go
@@ -1,0 +1,84 @@
+package yqlib
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestYamlEncoderUnwrapScalarRoundtripSafety verifies that a top-level string
+// scalar whose unquoted form would re-parse as a non-scalar node (map or
+// sequence) is emitted quoted even when UnwrapScalar is enabled. Safe plain
+// strings continue to round-trip through the existing fast-path. See #2608.
+func TestYamlEncoderUnwrapScalarRoundtripSafety(t *testing.T) {
+	cases := []struct {
+		name     string
+		value    string
+		wantBare bool // true: output equals value+"\n"; false: output must differ
+	}{
+		{name: "colon_parses_as_map", value: "this: should really work"},
+		{name: "dash_parses_as_seq", value: "- item"},
+		{name: "multiline_maplike", value: "a: a\nb: b"},
+		{name: "safe_plain_string", value: "hello world", wantBare: true},
+		{name: "safe_identifier", value: "cat", wantBare: true},
+		{name: "safe_digits_preserved", value: "123", wantBare: true},
+		{name: "safe_null_word_preserved", value: "null", wantBare: true},
+		{name: "safe_tag_shorthand_preserved", value: "!!int", wantBare: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefs := NewDefaultYamlPreferences()
+			prefs.UnwrapScalar = true
+
+			var buf bytes.Buffer
+			err := NewYamlEncoder(prefs).Encode(&buf, &CandidateNode{
+				Kind:  ScalarNode,
+				Tag:   "!!str",
+				Value: tc.value,
+			})
+			if err != nil {
+				t.Fatalf("encode failed: %v", err)
+			}
+			got := buf.String()
+
+			if tc.wantBare {
+				if got != tc.value+"\n" {
+					t.Fatalf("expected bare %q, got %q", tc.value+"\n", got)
+				}
+				return
+			}
+
+			// Ambiguous input: must not be emitted as the bare value.
+			if got == tc.value+"\n" {
+				t.Fatalf("value %q was emitted bare; expected quoted form", tc.value)
+			}
+
+			// The output must round-trip back to a string scalar with the
+			// same value, proving structural roundtrip safety.
+			decoder := NewYamlDecoder(NewDefaultYamlPreferences())
+			nodes, err := readDocuments(strings.NewReader(got), "test.yaml", 0, decoder)
+			if err != nil {
+				t.Fatalf("decode of %q failed: %v", got, err)
+			}
+			if nodes.Len() != 1 {
+				t.Fatalf("expected one document, got %d", nodes.Len())
+			}
+			candidate := nodes.Front().Value.(*CandidateNode)
+			// readDocuments wraps the document; descend to the scalar.
+			scalar := candidate
+			for scalar.Kind != ScalarNode && len(scalar.Content) == 1 {
+				scalar = scalar.Content[0]
+			}
+			if scalar.Kind != ScalarNode {
+				t.Fatalf("round-tripped node is not a scalar: kind=%v value=%q", scalar.Kind, scalar.Value)
+			}
+			if scalar.Tag != "!!str" {
+				t.Fatalf("round-tripped tag is %q, want !!str", scalar.Tag)
+			}
+			if scalar.Value != tc.value {
+				t.Fatalf("round-tripped value is %q, want %q", scalar.Value, tc.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The yaml encoder has a fast-path for unwrapping top-level scalars: when `UnwrapScalar` is set (the default for yaml output) it writes `node.Value` verbatim and skips the regular encoder. The fast-path never checks whether the bare form round-trips, so any `!!str` whose value happens to be a valid YAML mapping or sequence is silently reinterpreted on the next read.

Reproducer:

```
printf '"this: should really work"\n' | yq -p yaml -o yaml
```

Before this fix the second invocation parses the output as a single-key map, destroying the original string; the reporter's second example (`yq .foo` on a `foo: |` block containing `a: a` / `b: b`) hits the same path through the literal style.

Guard the fast-path with `bareStringNeedsQuoting`, which re-parses `node.Value` with yaml.v4 and reports whether the result is something other than a scalar. When it returns true the encoder falls through to the normal `encoder.Encode` path, which picks up `LiteralStyle` or `DoubleQuotedStyle` as appropriate. The check is deliberately narrow:

- only `!!str` nodes are examined, so existing tag tests that emit `!!int`/`!!str` as a bare scalar are untouched;
- only structural reinterpretations (map/sequence/alias) trigger the fallback, so plain strings that re-read as integers, booleans, or nulls keep their current unwrapped form;
- an unparseable value (e.g. one containing NUL) stays on the fast-path, so the NUL-aware printer in `printer.go` still sees the raw bytes.

The new table-driven test `TestYamlEncoderUnwrapScalarRoundtripSafety` covers the colon, dash, and multiline-map cases from the report and asserts that safe plain strings, digits, `null`, and `!!int` still emit bare. The `decode yaml document` base64 scenario previously asserted the buggy `a: apple\n` bare output; it now expects the block-literal form that round-trips back to the same string.

Fixes #2608