### PR TITLE
Fix repeatString overflow test on 32-bit platforms

### DIFF
--- a/pkg/yqlib/operator_multiply_test.go
+++ b/pkg/yqlib/operator_multiply_test.go
@@ -2,6 +2,7 @@ package yqlib
 
 import (
 	"fmt"
+	"math/bits"
 	"strings"
 	"testing"
 )
@@ -707,11 +708,13 @@ var multiplyOperatorScenarios = []expressionScenario{
 		expectedError: "result of repeating string (1 bytes) by 99999999 would exceed 10485760 bytes",
 	},
 	{
-		// The size guard must not overflow: len * count can wrap to
-		// a negative or small value on 64-bit, bypassing the check.
+		// Pick a count whose product with len("ab") overflows int on
+		// any architecture: 2^30 on 32-bit, 2^62 on 64-bit. Doubling
+		// either yields MaxInt+1, which wraps to MinInt and bypasses
+		// a naive len*count guard.
 		skipDoc:       true,
-		expression:    `"ab" * 4611686018427387904`,
-		expectedError: "result of repeating string (2 bytes) by 4611686018427387904 would exceed 10485760 bytes",
+		expression:    fmt.Sprintf(`"ab" * %d`, 1<<(bits.UintSize-2)),
+		expectedError: fmt.Sprintf("result of repeating string (2 bytes) by %d would exceed 10485760 bytes", 1<<(bits.UintSize-2)),
 	},
 }
 


### PR DESCRIPTION
The test literal "ab" * 4611686018427387904 (2^62) exceeds MaxInt32, so parseInt rejects it before the size guard runs. Compute the count with 1 << (bits.UintSize - 2) to yield 2^30 on 32-bit and 2^62 on 64-bit. Both values, when doubled by len("ab"), wrap past MaxInt and bypass a naive len*count guard, exercising the division-safe check added in #2644.

Ref https://github.com/mikefarah/yq/pull/2644#issuecomment-4297857398

I've verified that the modified test case still triggers the original panic on 64-bit platforms unless the fix from #2644 is applied.

I've also verified that this change fixes cross-compilation to 32-bit mode.

I am **NOT** able to test the 32-bit binary itself, so I don't know if it will pass tests, and I don't know if this code will still trigger the original bug. From a pure math perspective it should.