### PR TITLE
fix: reset TOML decoder between files when evaluating all at once

### DIFF
--- a/pkg/yqlib/all_at_once_evaluator_test.go
+++ b/pkg/yqlib/all_at_once_evaluator_test.go
@@ -54,3 +54,25 @@ func TestAllAtOnceEvaluateNodes(t *testing.T) {
 		test.AssertResultComplex(t, tt.expected, resultsToString(t, list))
 	}
 }
+
+func TestTomlDecoderCanBeReinitializedAcrossDocuments(t *testing.T) {
+	decoder := NewTomlDecoder()
+
+	firstDocuments, err := ReadDocuments(strings.NewReader("id = \"Foobar\"\n"), decoder)
+	if err != nil {
+		t.Fatalf("failed to read first TOML document: %v", err)
+	}
+	if firstDocuments.Len() != 1 {
+		t.Fatalf("expected first document count to be 1, got %d", firstDocuments.Len())
+	}
+	test.AssertResult(t, "Foobar", firstDocuments.Front().Value.(*CandidateNode).Content[1].Value)
+
+	secondDocuments, err := ReadDocuments(strings.NewReader("id = \"Barbar\"\n"), decoder)
+	if err != nil {
+		t.Fatalf("failed to read second TOML document: %v", err)
+	}
+	if secondDocuments.Len() != 1 {
+		t.Fatalf("expected second document count to be 1, got %d", secondDocuments.Len())
+	}
+	test.AssertResult(t, "Barbar", secondDocuments.Front().Value.(*CandidateNode).Content[1].Value)
+}

--- a/pkg/yqlib/all_at_once_evaluator_test.go
+++ b/pkg/yqlib/all_at_once_evaluator_test.go
@@ -67,12 +67,12 @@ func TestTomlDecoderCanBeReinitializedAcrossDocuments(t *testing.T) {
 	}
 	test.AssertResult(t, "Foobar", firstDocuments.Front().Value.(*CandidateNode).Content[1].Value)
 
-	secondDocuments, err := ReadDocuments(strings.NewReader("id = \"Barbar\"\n"), decoder)
+	secondDocuments, err := ReadDocuments(strings.NewReader("id = \"Banana\"\n"), decoder)
 	if err != nil {
 		t.Fatalf("failed to read second TOML document: %v", err)
 	}
 	if secondDocuments.Len() != 1 {
 		t.Fatalf("expected second document count to be 1, got %d", secondDocuments.Len())
 	}
-	test.AssertResult(t, "Barbar", secondDocuments.Front().Value.(*CandidateNode).Content[1].Value)
+	test.AssertResult(t, "Banana", secondDocuments.Front().Value.(*CandidateNode).Content[1].Value)
 }

--- a/pkg/yqlib/decoder_toml.go
+++ b/pkg/yqlib/decoder_toml.go
@@ -44,6 +44,7 @@ func (dec *tomlDecoder) Init(reader io.Reader) error {
 	}
 	dec.pendingComments = make([]string, 0)
 	dec.firstContentSeen = false
+	dec.finished = false
 	return nil
 }
 


### PR DESCRIPTION
## Problem

When using \EvaluateAllDocuments\ mode with multiple TOML files, the decoder's \inished\ flag was not being reset between files in the \Init\ method.

This caused the decoder to exit early on subsequent files after the first one returned EOF, silently producing incomplete output.

## Fix

Reset \dec.finished = false\ inside \Init\ so each new reader starts from a clean state.

## Test

Added a regression test in \ll_at_once_evaluator_test.go\ covering multi-file TOML evaluation.