### PR TITLE
Fix nested inline YAML merge explode

### DIFF
--- a/pkg/yqlib/operator_anchors_aliases.go
+++ b/pkg/yqlib/operator_anchors_aliases.go
@@ -170,6 +170,10 @@ func fixedReconstructAliasedMap(node *CandidateNode) error {
 				if mergeNodeSeq.Kind == AliasNode {
 					mergeNodeSeq = mergeNodeSeq.Alias
 				}
+				mergeNodeSeq = mergeNodeSeq.Copy()
+				if err := explodeNode(mergeNodeSeq, Context{}); err != nil {
+					return err
+				}
 				if mergeNodeSeq.Kind != MappingNode {
 					return fmt.Errorf("can only use merge anchors with maps (!!map) or sequences (!!seq) of maps, but got sequence containing %v", mergeNodeSeq.Tag)
 				}
@@ -179,12 +183,7 @@ func fixedReconstructAliasedMap(node *CandidateNode) error {
 				})
 
 				for _, item := range itemsToAdd {
-					// copy to ensure exploding doesn't modify the original node
-					itemCopy := item.Copy()
-					if err := explodeNode(itemCopy, Context{}); err != nil {
-						return err
-					}
-					newContent = append(newContent, itemCopy)
+					newContent = append(newContent, item.Copy())
 				}
 			}
 		}

--- a/pkg/yqlib/operator_anchors_aliases_test.go
+++ b/pkg/yqlib/operator_anchors_aliases_test.go
@@ -200,6 +200,15 @@ var fixedAnchorOperatorScenarios = []expressionScenario{
 	},
 	{
 		skipDoc:     true,
+		description: "Nested merge anchor with inline map",
+		document:    `{<<: {<<: {a: 42}}}`,
+		expression:  `explode(.)`,
+		expected: []string{
+			"D0, P[], (!!map)::{a: 42}\n",
+		},
+	},
+	{
+		skipDoc:     true,
 		description: "Merge anchor with sequence with inline map",
 		document:    `{<<: [{a: 42}]}`,
 		expression:  `explode(.)`,


### PR DESCRIPTION
## Summary
- Resolve nested merge keys in inline merge maps before filtering merged keys.
- Add a regression test for `explode(.)` with `{<<: {<<: {a: 42}}}`.

Fixes #2679.

## Tests
- `go test ./pkg/yqlib -run TestAnchorAliasOperatorAlignedToSpecScenarios -count=1`
- `go test ./pkg/yqlib -run 'TestAnchorAliasOperator(AlignedToSpec)?Scenarios' -count=1`\n- `printf '%s\\n' '{<<: {<<: {a: 42}}}' | go run . --yaml-fix-merge-anchor-to-spec 'explode(.)'`\n- `go test ./pkg/yqlib -count=1`\n- `go test ./...`\n- `./scripts/check.sh`\n- `./scripts/spelling.sh`\n- `git diff --check`