### PR TITLE
fix: handle expression arg that matches a filename

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -246,6 +246,20 @@ func maybeFile(str string) bool {
 	return result
 }
 
+func expressionLikeArg(str string) bool {
+	return strings.HasPrefix(str, ".") && !strings.HasPrefix(str, "./") && !strings.HasPrefix(str, "../")
+}
+
+func firstArgIsExpression(args []string, firstArgIsFile bool) bool {
+	if len(args) == 0 || args[0] == "-" {
+		return false
+	}
+	if !firstArgIsFile {
+		return true
+	}
+	return len(args) > 1 && expressionLikeArg(args[0])
+}
+
 func processStdInArgs(args []string) []string {
 	stat, err := os.Stdin.Stat()
 	if err != nil {
@@ -295,7 +309,7 @@ func processArgs(originalArgs []string) (string, []string, error) {
 	}
 
 	yqlib.GetLogger().Debugf("processed args: %v", args)
-	if expression == "" && len(args) > 0 && args[0] != "-" && !maybeFile(args[0]) {
+	if expression == "" && firstArgIsExpression(args, maybeFirstArgIsAFile) {
 		yqlib.GetLogger().Debugf("assuming expression is '%v'", args[0])
 		expression = args[0]
 		args = args[1:]

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -77,6 +77,9 @@ func TestMaybeFile(t *testing.T) {
 }
 
 func TestProcessArgs(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
 	// Create a temporary file for testing
 	tempFile, err := os.CreateTemp("", "test")
 	if err != nil {
@@ -95,6 +98,13 @@ func TestProcessArgs(t *testing.T) {
 		t.Fatalf("Failed to write to temp yq file: %v", err)
 	}
 	tempYqFile.Close()
+
+	if err := os.WriteFile(".version", []byte("boom"), 0o600); err != nil {
+		t.Fatalf("Failed to write .version file: %v", err)
+	}
+	if err := os.WriteFile("data.yml", []byte("version: 1.1.1"), 0o600); err != nil {
+		t.Fatalf("Failed to write data.yml file: %v", err)
+	}
 
 	tests := []struct {
 		name            string
@@ -130,6 +140,33 @@ func TestProcessArgs(t *testing.T) {
 			expressionFile:  "",
 			expectedExpr:    ".a.b",
 			expectedArgs:    []string{"file1"},
+			expectError:     false,
+		},
+		{
+			name:            "expression-looking file as first arg before file",
+			args:            []string{".version", "data.yml"},
+			forceExpression: "",
+			expressionFile:  "",
+			expectedExpr:    ".version",
+			expectedArgs:    []string{"data.yml"},
+			expectError:     false,
+		},
+		{
+			name:            "expression-looking file as first arg before stdin",
+			args:            []string{".version", "-"},
+			forceExpression: "",
+			expressionFile:  "",
+			expectedExpr:    ".version",
+			expectedArgs:    []string{"-"},
+			expectError:     false,
+		},
+		{
+			name:            "path-qualified expression-looking file stays file arg",
+			args:            []string{"./.version", "data.yml"},
+			forceExpression: "",
+			expressionFile:  "",
+			expectedExpr:    "",
+			expectedArgs:    []string{"./.version", "data.yml"},
 			expectError:     false,
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes expression arguments that happen to match an existing filename.

## What changed

- Added `processArgs()` regression coverage for `.version` when a same-named file exists and an input file or stdin follows it.
- Updated first-argument detection so expression-looking dot args followed by input are treated as expressions.
- Preserved single-file usage, `.yq` expression files, and explicit path-qualified file args such as `./.version`.

## Why

Before this change, `processArgs()` skipped expression detection when the first arg existed as a file, so `yq '.version' data.yml` could read `.version` as an input file instead of evaluating `.version` against `data.yml`.

After this change, `.version data.yml` and `.version -` are parsed as expression plus input, while users can still force file interpretation with `./.version`.

## Testing

- `go test ./cmd -run TestProcessArgs -count=1` failed before the production fix with `.version` left in args instead of becoming the expression.
- `go test ./cmd -run TestProcessArgs -count=1`
- `go test ./cmd -count=1`
- `go test ./...`
- `bash ./scripts/devtools.sh`
- `make local test`
- `git diff --check`

Fixes #2477

Note: I used Codex to help inspect the code path and draft the regression test, but I reviewed the final diff and ran the listed verification commands locally.