### PR TITLE
feat: add --split-exp-no-overwrite flag to refuse overwriting existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Flags:
       --shell-key-separator string      separator for shell variable key paths (default "_")
   -s, --split-exp string                print each result (or doc) into a file named (exp). [exp] argument must return a string. You can use $index in the expression as the result counter. The necessary directories will be created.
       --split-exp-file string           Use a file to specify the split-exp expression.
+      --split-exp-no-overwrite          When using --split-exp, fail if a target file already exists instead of overwriting it.
       --string-interpolation            Toggles strings interpolation of \(exp) (default true)
       --tsv-auto-parse                  parse TSV YAML/JSON values (default true)
   -r, --unwrapScalar                    unwrap scalar, print the value with no quotes, colors or comments. Defaults to true for yaml (default true)

--- a/cmd/constant.go
+++ b/cmd/constant.go
@@ -31,6 +31,7 @@ var frontMatter = ""
 
 var splitFileExp = ""
 var splitFileExpFile = ""
+var splitFileNoOverwrite = false
 
 var completedSuccessfully = false
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,6 +204,7 @@ yq -P -oy sample.json
 	if err = rootCmd.MarkPersistentFlagFilename("split-exp-file"); err != nil {
 		panic(err)
 	}
+	rootCmd.PersistentFlags().BoolVarP(&splitFileNoOverwrite, "split-exp-no-overwrite", "", false, "When using --split-exp, fail if a target file already exists instead of overwriting it.")
 
 	rootCmd.PersistentFlags().StringVarP(&expressionFile, "from-file", "", "", "Load expression from specified file.")
 	if err = rootCmd.MarkPersistentFlagFilename("from-file"); err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -186,7 +186,7 @@ func configurePrinterWriter(format *yqlib.Format, out io.Writer) (yqlib.PrinterW
 		if err != nil {
 			return nil, fmt.Errorf("bad split document expression: %w", err)
 		}
-		printerWriter = yqlib.NewMultiPrinterWriter(splitExp, format)
+		printerWriter = yqlib.NewMultiPrinterWriterWithOptions(splitExp, format, splitFileNoOverwrite)
 	} else {
 		printerWriter = yqlib.NewSinglePrinterWriter(out)
 	}

--- a/pkg/yqlib/printer_writer.go
+++ b/pkg/yqlib/printer_writer.go
@@ -32,9 +32,17 @@ type multiPrintWriter struct {
 	nameExpression *ExpressionNode
 	extension      string
 	index          int
+	noOverwrite    bool
 }
 
 func NewMultiPrinterWriter(expression *ExpressionNode, format *Format) PrinterWriter {
+	return NewMultiPrinterWriterWithOptions(expression, format, false)
+}
+
+// NewMultiPrinterWriterWithOptions creates a multi-file printer writer.
+// When noOverwrite is true, attempting to write to a file that already
+// exists will fail with an error instead of silently overwriting it.
+func NewMultiPrinterWriterWithOptions(expression *ExpressionNode, format *Format, noOverwrite bool) PrinterWriter {
 	extension := "yml"
 
 	switch format {
@@ -49,6 +57,7 @@ func NewMultiPrinterWriter(expression *ExpressionNode, format *Format) PrinterWr
 		extension:      extension,
 		treeNavigator:  NewDataTreeNavigator(),
 		index:          0,
+		noOverwrite:    noOverwrite,
 	}
 }
 
@@ -75,10 +84,20 @@ func (sp *multiPrintWriter) GetWriter(node *CandidateNode) (*bufio.Writer, error
 	if err != nil {
 		return nil, err
 	}
-	f, err := os.Create(name)
-
-	if err != nil {
-		return nil, err
+	var f *os.File
+	if sp.noOverwrite {
+		f, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err != nil {
+			if os.IsExist(err) {
+				return nil, fmt.Errorf("refusing to overwrite existing file %q (--no-overwrite is set)", name)
+			}
+			return nil, err
+		}
+	} else {
+		f, err = os.Create(name)
+		if err != nil {
+			return nil, err
+		}
 	}
 	sp.index = sp.index + 1
 

--- a/pkg/yqlib/printer_writer_test.go
+++ b/pkg/yqlib/printer_writer_test.go
@@ -1,0 +1,96 @@
+package yqlib
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helper to build an ExpressionNode that just yields a fixed string for the file name
+func parseFilenameExp(t *testing.T, exp string) *ExpressionNode {
+	t.Helper()
+	InitExpressionParser()
+	node, err := ExpressionParser.ParseExpression(exp)
+	if err != nil {
+		t.Fatalf("failed to parse split-exp test expression %q: %v", exp, err)
+	}
+	return node
+}
+
+func TestMultiPrinterWriterOverwriteDefault(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.yml")
+	if err := os.WriteFile(target, []byte("pre-existing\n"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	exp := parseFilenameExp(t, `"`+target+`"`)
+	pw := NewMultiPrinterWriter(exp, YamlFormat)
+
+	node := &CandidateNode{Kind: ScalarNode, Tag: "!!str", Value: "hello"}
+	w, err := pw.GetWriter(node)
+	if err != nil {
+		t.Fatalf("default behaviour should silently overwrite, got error: %v", err)
+	}
+	if w == nil {
+		t.Fatalf("expected a writer, got nil")
+	}
+	// confirm the file was truncated/recreated by os.Create
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("expected file to be truncated (size 0) before writes, got %d bytes", info.Size())
+	}
+}
+
+func TestMultiPrinterWriterNoOverwriteRefusesExisting(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.yml")
+	if err := os.WriteFile(target, []byte("pre-existing\n"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	exp := parseFilenameExp(t, `"`+target+`"`)
+	pw := NewMultiPrinterWriterWithOptions(exp, YamlFormat, true)
+
+	node := &CandidateNode{Kind: ScalarNode, Tag: "!!str", Value: "hello"}
+	_, err := pw.GetWriter(node)
+	if err == nil {
+		t.Fatalf("expected error when --no-overwrite is set and target exists, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Fatalf("expected refusing-to-overwrite error message, got: %v", err)
+	}
+
+	// file must be untouched
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(data) != "pre-existing\n" {
+		t.Fatalf("file should be untouched, contents = %q", string(data))
+	}
+}
+
+func TestMultiPrinterWriterNoOverwriteCreatesNew(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "new.yml")
+
+	exp := parseFilenameExp(t, `"`+target+`"`)
+	pw := NewMultiPrinterWriterWithOptions(exp, YamlFormat, true)
+
+	node := &CandidateNode{Kind: ScalarNode, Tag: "!!str", Value: "hello"}
+	w, err := pw.GetWriter(node)
+	if err != nil {
+		t.Fatalf("no-overwrite should still create new files, got: %v", err)
+	}
+	if w == nil {
+		t.Fatalf("expected a writer, got nil")
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected new file to exist, stat err: %v", err)
+	}
+}


### PR DESCRIPTION
### What

Adds an opt-in `--split-exp-no-overwrite` flag that makes `--split-exp` refuse to overwrite any pre-existing file at a target path, instead failing fast with a clear error message. The existing default behaviour (silent overwrite via `os.Create`) is unchanged.

Closes #2028.

### Why

When yq splits documents into per-file outputs, file names are usually derived from the input data itself, e.g.:

```bash
yq -s '.metadata.name + "_" + .kind' all.yaml
```

If two input documents map to the same name, or if a target path happens to already exist on disk, the second write silently clobbers whatever was there because `os.Create` truncates. That's a footgun for CI pipelines and bulk-conversion scripts where the user would much rather see an error and fix the expression than discover a missing/overwritten file later.

The issue author asked for an explicit opt-in flag rather than changing the default, which is what this PR does.

### How

- Added a new yqlib constructor `NewMultiPrinterWriterWithOptions(expression, format, noOverwrite)` that carries the new option.
- The original `NewMultiPrinterWriter` is preserved and now just delegates to the new constructor with `noOverwrite=false`, so the public API is fully backwards compatible.
- When `noOverwrite` is true, the writer uses `os.OpenFile(name, O_WRONLY|O_CREATE|O_EXCL, 0600)`. If the target exists, yq returns:

  ```
  Error: refusing to overwrite existing file "file_0.yml" (--no-overwrite is set)
  ```

  and leaves the existing file's contents untouched.
- Wired up a new `--split-exp-no-overwrite` persistent flag on the root command, defaulting to `false`.
- Updated the `--help` snippet in `README.md` to include the new flag.

### Tests

Added `pkg/yqlib/printer_writer_test.go` covering three scenarios:

1. **Default behaviour** — existing files are still silently truncated/overwritten (regression guard).
2. **`--no-overwrite` refuses existing files** — `GetWriter` returns an error containing `"refusing to overwrite"`, and the pre-existing file's contents are verified to be untouched.
3. **`--no-overwrite` still creates new files** — confirms the flag doesn't break the normal "first write" path.

All existing tests pass:

```
$ go test ./...
ok  	github.com/mikefarah/yq/v4	1.385s
ok  	github.com/mikefarah/yq/v4/cmd	0.620s
ok  	github.com/mikefarah/yq/v4/pkg/yqlib	1.049s
ok  	github.com/mikefarah/yq/v4/test	1.806s
```

### Manual smoke test

```bash
$ printf 'a: 1\n---\nb: 2\n' | yq -s '"file_" + $index'
$ ls
file_0.yml  file_1.yml

# Default: silent overwrite (existing behaviour)
$ printf 'X: 9\n---\nY: 8\n' | yq -s '"file_" + $index'
$ cat file_0.yml
X: 9

# With --split-exp-no-overwrite: fails fast, leaves file alone
$ printf 'A: 7\n---\nB: 6\n' | yq -s '"file_" + $index' --split-exp-no-overwrite
Error: refusing to overwrite existing file "file_0.yml" (--no-overwrite is set)
$ cat file_0.yml
X: 9    # untouched
```
