### PR TITLE
fix: reset INI decoder state on init

### DIFF
--- a/pkg/yqlib/decoder_ini.go
+++ b/pkg/yqlib/decoder_ini.go
@@ -23,6 +23,7 @@ func NewINIDecoder() Decoder {
 func (dec *iniDecoder) Init(reader io.Reader) error {
 	// Store the reader for use in Decode
 	dec.reader = reader
+	dec.finished = false
 	return nil
 }
 

--- a/pkg/yqlib/ini_test.go
+++ b/pkg/yqlib/ini_test.go
@@ -5,6 +5,7 @@ package yqlib
 import (
 	"bufio"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mikefarah/yq/v4/test"
@@ -173,6 +174,21 @@ func documentDecodeErrorINIScenario(w *bufio.Writer, s formatScenario) {
 
 	writeOrPanic(w, "then an error is expected:\n")
 	writeOrPanic(w, fmt.Sprintf("```\n%v\n```\n\n", s.expectedError))
+}
+
+func TestINIDecoderInitResetsFinished(t *testing.T) {
+	decoder := NewINIDecoder()
+	firstDocuments, err := readDocuments(strings.NewReader("[first]\nkey = value\n"), "first.ini", 0, decoder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.AssertResult(t, 1, firstDocuments.Len())
+
+	secondDocuments, err := readDocuments(strings.NewReader("[second]\nkey = value\n"), "second.ini", 1, decoder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.AssertResult(t, 1, secondDocuments.Len())
 }
 
 func TestINIScenarios(t *testing.T) {


### PR DESCRIPTION
Generated by Hermes + GPT-5.5.

## Summary

- Reset the INI decoder's `finished` flag in `Init`
- Add a regression test covering decoder reuse across multiple inputs

## Context

`eval-all` reuses the same decoder instance for each input file. The INI decoder set `finished = true` after decoding the first input, but did not reset it in `Init`, so subsequent files were treated as EOF immediately.

This caused commands such as:

```bash
yq ea -p ini -o yaml '{"fi": fileIndex, "fn": filename, "doc": .}' a.ini b.ini
```

to only process `a.ini`.

## Test Plan

```bash
GOPROXY=https://goproxy.cn,direct go test ./pkg/yqlib -run "TestINIDecoderInitResetsFinished|TestINIScenarios"
```

Also manually verified:

```bash
go run . ea -p ini -o yaml '{"fi": fileIndex, "fn": filename, "doc": .}' a.ini b.ini
```

now outputs both `fileIndex: 0` and `fileIndex: 1`.
