### PR TITLE
feat: add `in` operator (inverse of `has`)

### DIFF
--- a/pkg/yqlib/doc/operators/in.md
+++ b/pkg/yqlib/doc/operators/in.md
@@ -1,0 +1,121 @@
+
+## Check key exists in map using variable binding
+Given a sample.yml file of:
+```yaml
+a: 1
+b: 2
+c: 3
+```
+then
+```bash
+yq '. as $m | "a" | in($m)' sample.yml
+```
+will output
+```yaml
+true
+```
+
+## Check key does not exist in map
+Given a sample.yml file of:
+```yaml
+a: 1
+b: 2
+c: 3
+```
+then
+```bash
+yq '. as $m | "d" | in($m)' sample.yml
+```
+will output
+```yaml
+false
+```
+
+## Check value exists in array
+Given a sample.yml file of:
+```yaml
+- Tool
+- Food
+- Flower
+```
+then
+```bash
+yq '. as $m | "Food" | in($m)' sample.yml
+```
+will output
+```yaml
+true
+```
+
+## Check value does not exist in array
+Given a sample.yml file of:
+```yaml
+- Tool
+- Food
+- Flower
+```
+then
+```bash
+yq '. as $m | "Animal" | in($m)' sample.yml
+```
+will output
+```yaml
+false
+```
+
+## Check in with select on array elements
+Filter items whose type is in the given list
+
+Given a sample.yml file of:
+```yaml
+- item: Pizza
+  type: Food
+- item: Rose
+  type: Flower
+- item: Hammer
+  type: Tool
+```
+then
+```bash
+yq '.[] | select(.type | in(["Tool", "Food"]))' sample.yml
+```
+will output
+```yaml
+item: Pizza
+type: Food
+item: Hammer
+type: Tool
+```
+
+## In with variable binding - found
+Given a sample.yml file of:
+```yaml
+a: 1
+b: 2
+c: 3
+```
+then
+```bash
+yq '. as $m | "b" | in($m)' sample.yml
+```
+will output
+```yaml
+true
+```
+
+## In with variable binding - not found
+Given a sample.yml file of:
+```yaml
+a: 1
+b: 2
+c: 3
+```
+then
+```bash
+yq '. as $m | "z" | in($m)' sample.yml
+```
+will output
+```yaml
+false
+```
+

--- a/pkg/yqlib/lexer_participle.go
+++ b/pkg/yqlib/lexer_participle.go
@@ -102,6 +102,7 @@ var participleYqRules = []*participleYqRule{
 
 	simpleOp("select", selectOpType),
 	simpleOp("has", hasOpType),
+	simpleOp("in", inOpType),
 	simpleOp("unique_?by", uniqueByOpType),
 	simpleOp("unique", uniqueOpType),
 

--- a/pkg/yqlib/operation.go
+++ b/pkg/yqlib/operation.go
@@ -191,6 +191,7 @@ var recursiveDescentOpType = &operationType{Type: "RECURSIVE_DESCENT", NumArgs: 
 
 var selectOpType = &operationType{Type: "SELECT", NumArgs: 1, Precedence: 52, Handler: selectOperator, CheckForPostTraverse: true}
 var hasOpType = &operationType{Type: "HAS", NumArgs: 1, Precedence: 50, Handler: hasOperator}
+var inOpType = &operationType{Type: "IN", NumArgs: 1, Precedence: 50, Handler: inOperator}
 var uniqueOpType = &operationType{Type: "UNIQUE", NumArgs: 0, Precedence: 52, Handler: unique, CheckForPostTraverse: true}
 var uniqueByOpType = &operationType{Type: "UNIQUE_BY", NumArgs: 1, Precedence: 52, Handler: uniqueBy, CheckForPostTraverse: true}
 var groupByOpType = &operationType{Type: "GROUP_BY", NumArgs: 1, Precedence: 52, Handler: groupBy, CheckForPostTraverse: true}

--- a/pkg/yqlib/operator_in.go
+++ b/pkg/yqlib/operator_in.go
@@ -1,0 +1,59 @@
+package yqlib
+
+import (
+	"container/list"
+)
+
+func inOperator(d *dataTreeNavigator, context Context, expressionNode *ExpressionNode) (Context, error) {
+
+	log.Debugf("inOperation")
+	var results = list.New()
+
+	rhs, err := d.GetMatchingNodes(context.ReadOnlyClone(), expressionNode.RHS)
+
+	if err != nil {
+		return Context{}, err
+	}
+
+	var collection *CandidateNode
+	if rhs.MatchingNodes.Len() != 0 {
+		collection = rhs.MatchingNodes.Front().Value.(*CandidateNode)
+	} else {
+		// no collection provided, return false for all
+		for el := context.MatchingNodes.Front(); el != nil; el = el.Next() {
+			candidate := el.Value.(*CandidateNode)
+			results.PushBack(createBooleanCandidate(candidate, false))
+		}
+		return context.ChildContext(results), nil
+	}
+
+	for el := context.MatchingNodes.Front(); el != nil; el = el.Next() {
+		candidate := el.Value.(*CandidateNode)
+		isIn := false
+
+		switch collection.Kind {
+		case MappingNode:
+			// Check if candidate value exists as a key in the mapping
+			for index := 0; index < len(collection.Content); index = index + 2 {
+				key := collection.Content[index]
+				if key.Value == candidate.Value {
+					isIn = true
+					break
+				}
+			}
+		case SequenceNode:
+			// Check if candidate value is present in the sequence (value membership)
+			for _, element := range collection.Content {
+				if element.Value == candidate.Value {
+					isIn = true
+					break
+				}
+			}
+		default:
+			isIn = false
+		}
+
+		results.PushBack(createBooleanCandidate(candidate, isIn))
+	}
+	return context.ChildContext(results), nil
+}

--- a/pkg/yqlib/operator_in_test.go
+++ b/pkg/yqlib/operator_in_test.go
@@ -1,0 +1,105 @@
+package yqlib
+
+import (
+	"testing"
+)
+
+var inOperatorScenarios = []expressionScenario{
+	{
+		description: "Check key exists in map using variable binding",
+		document:    "a: 1\nb: 2\nc: 3\n",
+		expression:  `. as $m | "a" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::true\n",
+		},
+	},
+	{
+		description: "Check key does not exist in map",
+		document:    "a: 1\nb: 2\nc: 3\n",
+		expression:  `. as $m | "d" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::false\n",
+		},
+	},
+	{
+		description: "Check value exists in array",
+		document:    "- Tool\n- Food\n- Flower\n",
+		expression:  `. as $m | "Food" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::true\n",
+		},
+	},
+	{
+		description: "Check value does not exist in array",
+		document:    "- Tool\n- Food\n- Flower\n",
+		expression:  `. as $m | "Animal" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::false\n",
+		},
+	},
+	{
+		description:    "Check in with select on array elements",
+		subdescription: "Filter items whose type is in the given list",
+		document:       "- {item: Pizza, type: Food}\n- {item: Rose, type: Flower}\n- {item: Hammer, type: Tool}\n",
+		expression:     `.[] | select(.type | in(["Tool", "Food"]))`,
+		expected: []string{
+			"D0, P[0], (!!map)::{item: Pizza, type: Food}\n",
+			"D0, P[2], (!!map)::{item: Hammer, type: Tool}\n",
+		},
+	},
+	{
+		description: "In with variable binding - found",
+		document:    "a: 1\nb: 2\nc: 3\n",
+		expression:  `. as $m | "b" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::true\n",
+		},
+	},
+	{
+		description: "In with variable binding - not found",
+		document:    "a: 1\nb: 2\nc: 3\n",
+		expression:  `. as $m | "z" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::false\n",
+		},
+	},
+	{
+		skipDoc:    true,
+		document:   "- one\n- two\n- three\n",
+		expression: `. as $m | "one" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::true\n",
+		},
+	},
+	{
+		skipDoc:    true,
+		document:   "- one\n- two\n- three\n",
+		expression: `. as $m | "five" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::false\n",
+		},
+	},
+	{
+		skipDoc:    true,
+		document:   "key: value\nother: stuff\n",
+		expression: `. as $m | "key" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::true\n",
+		},
+	},
+	{
+		skipDoc:    true,
+		document:   "key: value\nother: stuff\n",
+		expression: `. as $m | "missing" | in($m)`,
+		expected: []string{
+			"D0, P[], (!!bool)::false\n",
+		},
+	},
+}
+
+func TestInOperatorScenarios(t *testing.T) {
+	for _, tt := range inOperatorScenarios {
+		testScenario(t, &tt)
+	}
+	documentOperatorScenarios(t, "in", inOperatorScenarios)
+}


### PR DESCRIPTION
## What

Add the `in` operator to yq, mirroring jq's `in` operator (inverse of `has`).

## Why

Closes #2322. The `in` operator checks whether a value is present in a mapping (as a key) or sequence (as an element), enabling idiomatic membership filtering in yq expressions.

## Usage

```yaml
# data.yml
- {item: Pizza, type: Food}
- {item: Rose, type: Flower}
- {item: Hammer, type: Tool}
```

```bash
# Filter by membership — select items whose type is Tool or Food
yq '.[] | select(.type | in(["Tool", "Food"]))' data.yml
```

```yaml
# Output
{item: Pizza, type: Food}
{item: Hammer, type: Tool}
```

```bash
# Check map key existence (using variable binding)
echo 'a: 1' | yq '. as $m | "a" | in($m)'
# true
```

## Implementation

- **`operator_in.go`** — Handler function: evaluates the RHS to get the collection, then checks if the LHS (piped-in value) is present as a key in a mapping or as an element in a sequence.
- **`operator_in_test.go`** — 11 test scenarios covering map key checks, array value membership, `select()` integration, and variable binding patterns.
- **`operation.go`** — Registers `inOpType` with `NumArgs: 1, Precedence: 50`.
- **`lexer_participle.go`** — Adds `simpleOp("in", inOpType)` to the lexer.

## Note on context model

Because RHS arguments are evaluated in the pipe context (not the root document), `in(.)` evaluates `.` as the piped value, not the original document. Use variable bindings to capture the collection first:

```bash
# Does NOT work as expected (`. evaluates to the pipe input):
echo 'a: 1' | yq '"a" | in(.)'  # false

# Works correctly (capture document in variable):
echo 'a: 1' | yq '. as $m | "a" | in($m)'  # true
```

This matches yq's existing context model (same as `has` with complex expressions).
