### PR TITLE
feat: add --ini-preserve-quotes flag for INI round-trip quote preservation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,6 +156,8 @@ yq -P -oy sample.json
 	rootCmd.PersistentFlags().BoolVar(&yqlib.ConfiguredLuaPreferences.UnquotedKeys, "lua-unquoted", yqlib.ConfiguredLuaPreferences.UnquotedKeys, "output unquoted string keys (e.g. {foo=\"bar\"})")
 	rootCmd.PersistentFlags().BoolVar(&yqlib.ConfiguredLuaPreferences.Globals, "lua-globals", yqlib.ConfiguredLuaPreferences.Globals, "output keys as top-level global variables")
 
+	rootCmd.PersistentFlags().BoolVar(&yqlib.ConfiguredINIPreferences.PreserveSurroundedQuote, "ini-preserve-quotes", yqlib.ConfiguredINIPreferences.PreserveSurroundedQuote, "preserve surrounding quotes on INI values during round-trip")
+
 	rootCmd.PersistentFlags().StringVar(&yqlib.ConfiguredPropertiesPreferences.KeyValueSeparator, "properties-separator", yqlib.ConfiguredPropertiesPreferences.KeyValueSeparator, "separator to use between keys and values")
 	rootCmd.PersistentFlags().BoolVar(&yqlib.ConfiguredPropertiesPreferences.UseArrayBrackets, "properties-array-brackets", yqlib.ConfiguredPropertiesPreferences.UseArrayBrackets, "use [x] in array paths (e.g. for SpringBoot)")
 

--- a/pkg/yqlib/decoder_ini.go
+++ b/pkg/yqlib/decoder_ini.go
@@ -12,11 +12,13 @@ import (
 type iniDecoder struct {
 	reader   io.Reader
 	finished bool // Flag to signal completion of processing
+	prefs    INIPreferences
 }
 
-func NewINIDecoder() Decoder {
+func NewINIDecoder(prefs INIPreferences) Decoder {
 	return &iniDecoder{
 		finished: false, // Initialise the flag as false
+		prefs:    prefs,
 	}
 }
 
@@ -39,7 +41,10 @@ func (dec *iniDecoder) Decode() (*CandidateNode, error) {
 	}
 
 	// Parse the INI content
-	cfg, err := ini.Load(content)
+	loadOpts := ini.LoadOptions{
+		PreserveSurroundedQuote: dec.prefs.PreserveSurroundedQuote,
+	}
+	cfg, err := ini.LoadSources(loadOpts, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse INI content: %w", err)
 	}

--- a/pkg/yqlib/format.go
+++ b/pkg/yqlib/format.go
@@ -90,7 +90,7 @@ var LuaFormat = &Format{"lua", []string{"l"},
 
 var INIFormat = &Format{"ini", []string{"i"},
 	func() Encoder { return NewINIEncoder() },
-	func() Decoder { return NewINIDecoder() },
+	func() Decoder { return NewINIDecoder(ConfiguredINIPreferences) },
 }
 
 var Formats = []*Format{

--- a/pkg/yqlib/ini.go
+++ b/pkg/yqlib/ini.go
@@ -1,18 +1,21 @@
 package yqlib
 
 type INIPreferences struct {
-	ColorsEnabled bool
+	ColorsEnabled           bool
+	PreserveSurroundedQuote bool
 }
 
 func NewDefaultINIPreferences() INIPreferences {
 	return INIPreferences{
-		ColorsEnabled: false,
+		ColorsEnabled:           false,
+		PreserveSurroundedQuote: false,
 	}
 }
 
 func (p *INIPreferences) Copy() INIPreferences {
 	return INIPreferences{
-		ColorsEnabled: p.ColorsEnabled,
+		ColorsEnabled:           p.ColorsEnabled,
+		PreserveSurroundedQuote: p.PreserveSurroundedQuote,
 	}
 }
 

--- a/pkg/yqlib/ini_test.go
+++ b/pkg/yqlib/ini_test.go
@@ -22,6 +22,16 @@ const expectedSimpleINIYaml = `section:
   key: value
 `
 
+const quotedINIInput = `[section]
+color_theme = "Default"
+theme_background = "False"
+`
+
+const expectedQuotedINIOutput = `[section]
+color_theme      = "Default"
+theme_background = "False"
+`
+
 var iniScenarios = []formatScenario{
 	{
 		description:  "Parse INI: simple",
@@ -49,6 +59,22 @@ var iniScenarios = []formatScenario{
 	},
 }
 
+// iniPreserveQuotesPrefs returns INIPreferences with PreserveSurroundedQuote enabled.
+func iniPreserveQuotesPrefs() INIPreferences {
+	prefs := NewDefaultINIPreferences()
+	prefs.PreserveSurroundedQuote = true
+	return prefs
+}
+
+var iniPreserveQuotesScenarios = []formatScenario{
+	{
+		description:  "Roundtrip INI: preserve quotes",
+		input:        quotedINIInput,
+		expected:     expectedQuotedINIOutput,
+		scenarioType: "roundtrip",
+	},
+}
+
 func documentRoundtripINIScenario(w *bufio.Writer, s formatScenario) {
 	writeOrPanic(w, fmt.Sprintf("## %v\n", s.description))
 
@@ -70,7 +96,7 @@ func documentRoundtripINIScenario(w *bufio.Writer, s formatScenario) {
 	}
 
 	writeOrPanic(w, "will output\n")
-	writeOrPanic(w, fmt.Sprintf("```ini\n%v```\n\n", mustProcessFormatScenario(s, NewINIDecoder(), NewINIEncoder())))
+	writeOrPanic(w, fmt.Sprintf("```ini\n%v```\n\n", mustProcessFormatScenario(s, NewINIDecoder(NewDefaultINIPreferences()), NewINIEncoder())))
 }
 
 func documentDecodeINIScenario(w *bufio.Writer, s formatScenario) {
@@ -94,7 +120,7 @@ func documentDecodeINIScenario(w *bufio.Writer, s formatScenario) {
 	}
 
 	writeOrPanic(w, "will output\n")
-	writeOrPanic(w, fmt.Sprintf("```yaml\n%v```\n\n", mustProcessFormatScenario(s, NewINIDecoder(), NewYamlEncoder(ConfiguredYamlPreferences))))
+	writeOrPanic(w, fmt.Sprintf("```yaml\n%v```\n\n", mustProcessFormatScenario(s, NewINIDecoder(NewDefaultINIPreferences()), NewYamlEncoder(ConfiguredYamlPreferences))))
 }
 
 func testINIScenario(t *testing.T, s formatScenario) {
@@ -102,11 +128,11 @@ func testINIScenario(t *testing.T, s formatScenario) {
 	case "encode":
 		test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewYamlDecoder(ConfiguredYamlPreferences), NewINIEncoder()), s.description)
 	case "decode":
-		test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewINIDecoder(), NewYamlEncoder(ConfiguredYamlPreferences)), s.description)
+		test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewINIDecoder(NewDefaultINIPreferences()), NewYamlEncoder(ConfiguredYamlPreferences)), s.description)
 	case "roundtrip":
-		test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewINIDecoder(), NewINIEncoder()), s.description)
+		test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewINIDecoder(NewDefaultINIPreferences()), NewINIEncoder()), s.description)
 	case "decode-error":
-		result, err := processFormatScenario(s, NewINIDecoder(), NewINIEncoder())
+		result, err := processFormatScenario(s, NewINIDecoder(NewDefaultINIPreferences()), NewINIEncoder())
 		if err == nil {
 			t.Errorf("Expected error '%v' but it worked: %v", s.expectedError, result)
 		} else {
@@ -184,4 +210,20 @@ func TestINIScenarios(t *testing.T) {
 		genericScenarios[i] = s
 	}
 	documentScenarios(t, "usage", "convert", genericScenarios, documentINIScenario)
+}
+
+func testINIPreserveQuotesScenario(t *testing.T, s formatScenario) {
+	prefs := iniPreserveQuotesPrefs()
+	switch s.scenarioType {
+	case "roundtrip":
+		test.AssertResultWithContext(t, s.expected, mustProcessFormatScenario(s, NewINIDecoder(prefs), NewINIEncoder()), s.description)
+	default:
+		panic(fmt.Sprintf("unhandled scenario type %q", s.scenarioType))
+	}
+}
+
+func TestINIPreserveQuotesScenarios(t *testing.T) {
+	for _, tt := range iniPreserveQuotesScenarios {
+		testINIPreserveQuotesScenario(t, tt)
+	}
 }

--- a/pkg/yqlib/no_ini.go
+++ b/pkg/yqlib/no_ini.go
@@ -2,7 +2,7 @@
 
 package yqlib
 
-func NewINIDecoder() Decoder {
+func NewINIDecoder(prefs INIPreferences) Decoder {
 	return nil
 }
 


### PR DESCRIPTION
## What

Add a `--ini-preserve-quotes` CLI flag that preserves surrounding quotes on INI values during decode/encode round-trips.

## Why

When round-tripping INI files (`-p=ini -o=ini`), quoted values like `color_theme = "Default"` are currently written back as `color_theme = Default` (quotes stripped). This breaks tools that ship configs with quoted strings and expect them to remain quoted.

Fixes #2456.

## How

- Added `PreserveSurroundedQuote` field to `INIPreferences` struct
- Wired it through to `go-ini/ini`'s `LoadOptions.PreserveSurroundedQuote` in the decoder
- Added `--ini-preserve-quotes` CLI flag in `cmd/root.go`
- Updated `NewINIDecoder()` to accept `INIPreferences` (matching the pattern of `NewYamlDecoder`, `NewXMLDecoder`, etc.)

## Example

```ini
# input: btop.ini
color_theme = "Default"
theme_background = "False"
```

**Without flag** (current behaviour):
```bash
yq -p=ini -o=ini '.' btop.ini
# color_theme = Default
# theme_background = False
```

**With flag**:
```bash
yq -p=ini -o=ini --ini-preserve-quotes '.' btop.ini
# color_theme      = "Default"
# theme_background = "False"
```

## Tests

- Existing INI tests pass (backwards compatible - default is `false`)
- Added `TestINIPreserveQuotesScenarios` with round-trip test for quoted values
