### PR TITLE
fix: preserve correct parent references in explode merge anchor reconstruction

### DIFF
--- a/pkg/yqlib/operator_anchors_aliases.go
+++ b/pkg/yqlib/operator_anchors_aliases.go
@@ -183,7 +183,9 @@ func fixedReconstructAliasedMap(node *CandidateNode) error {
 				})
 
 				for _, item := range itemsToAdd {
-					newContent = append(newContent, item.Copy())
+					copied := item.Copy()
+					copied.Parent = node
+					newContent = append(newContent, copied)
 				}
 			}
 		}
@@ -226,8 +228,12 @@ func reconstructAliasedMap(node *CandidateNode, context Context) error {
 		}
 	}
 	node.Content = make([]*CandidateNode, 0)
+	entries := make([]*CandidateNode, 0, newContent.Len())
 	for newEl := newContent.Front(); newEl != nil; newEl = newEl.Next() {
-		node.AddChild(newEl.Value.(*CandidateNode))
+		entries = append(entries, newEl.Value.(*CandidateNode))
+	}
+	for i := 0; i < len(entries); i += 2 {
+		node.AddKeyValueChild(entries[i], entries[i+1])
 	}
 	return nil
 }

--- a/pkg/yqlib/operator_anchors_aliases_test.go
+++ b/pkg/yqlib/operator_anchors_aliases_test.go
@@ -234,6 +234,29 @@ var fixedAnchorOperatorScenarios = []expressionScenario{
 			"D0, P[], (!!map)::a:\n    b: 42\nb: 42\n",
 		},
 	},
+	{
+		skipDoc:     true,
+		description: "Merge after explode preserves correct parent references",
+		document:    `opensearch: &opensearch-cluster
+  ip2geo:
+    enabled: false
+
+opensearch-client:
+  <<: *opensearch-cluster
+  nodeGroup: client
+  opensearchJavaOpts: "-Xmx1024m -Xms1024m"`,
+		document2: `opensearch: &opensearch-cluster
+  ip2geo:
+    enabled: true
+
+opensearch-client:
+  <<: *opensearch-cluster
+  opensearchJavaOpts: "-Xmx1536m -Xms1536m"`,
+		expression: `(select(fi == 0) | explode(.)) * (select(fi == 1) | explode(.))`,
+		expected: []string{
+			"D0, P[], (!!map)::opensearch:\n    ip2geo:\n        enabled: true\nopensearch-client:\n    ip2geo:\n        enabled: true\n    nodeGroup: client\n    opensearchJavaOpts: \"-Xmx1536m -Xms1536m\"\n",
+		},
+	},
 }
 
 var badAnchorOperatorScenarios = []expressionScenario{


### PR DESCRIPTION
## Bug
Fixes #2434 — Explode & Merge with brackets doesn't match order.

When using `explode(.) * ...` with `--yaml-fix-merge-anchor-to-spec`, children of merge-anchored nodes had wrong parent pointers, causing the merge operator to target incorrect LHS keys.

## Root Cause

In `fixedReconstructAliasedMap`, `item.Copy()` preserves the old parent reference from the alias target. When `GetPath()` later builds traversal paths for RHS candidates, children of `opensearch-client` would have paths like `opensearch.ip2geo.enabled` instead of `opensearch-client.ip2geo.enabled`, writing to the wrong target.

Similarly in `reconstructAliasedMap` (non-spec path), `node.AddChild()` was used for mapping nodes, which treats entries as sequence elements with numeric indices (0, 1, 2, 3...) instead of proper key-value pairs.

## Changes

### `fixedReconstructAliasedMap` (spec path)
- Set `copied.Parent = node` after copying each merge-anchor item

### `reconstructAliasedMap` (non-spec path)
- Replace `AddChild` (sequence-style) with `AddKeyValueChild` (mapping-style)
- This also fixes parent references via AddKeyValueChild's built-in SetParent

### Test
- Added regression test with multi-document merge of OpenSearch cluster configs