### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# yq — agent instructions
+
+See [agents.md](./agents.md) for contributor workflow (formatting, testing patterns, adding encoders/decoders).
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+**yq** is a Go CLI for querying and transforming YAML, JSON, XML, INI, and other structured formats. There are no long-running services — development is build-and-test against a local `./yq` binary.
+
+### Prerequisites
+
+- **Go ≥ 1.25** (see `go.mod`)
+- **Node.js** (for `npx cspell` spelling checks in the full `make test` pipeline)
+- **Bash** (acceptance tests)
+- **Docker/Podman** is optional; use `make local <target>` to run natively when containers are unavailable
+
+### PATH
+
+After `scripts/devtools.sh`, add Go tool binaries to PATH:
+
+```bash
+export PATH="$HOME/go/bin:$PATH"
+```
+
+`golangci-lint` installs to `$HOME/go/bin`; `gosec` installs to `./bin/gosec` in the repo root.
+
+### Common commands (local, no Docker)
+
+| Task | Command |
+|------|---------|
+| Install dev tools | `bash scripts/devtools.sh` |
+| Vendor dependencies | `make local vendor` |
+| Build binary | `go build -o yq .` or `make local build` |
+| Format | `make local format` |
+| Lint | `make local check` |
+| Unit tests | `make local test` or `bash scripts/test.sh` |
+| Acceptance (E2E) | `bash scripts/acceptance.sh` (requires `./yq` built first) |
+
+`make local build` runs the full CI chain (format → spelling → gosec → lint → unit tests → build → acceptance). For a faster loop, build with `go build -o yq .` and run `bash scripts/acceptance.sh`.
+
+### Gotchas
+
+- **`make` without `local`** tries Docker/Podman (`Dockerfile.dev`). In Cloud Agent VMs without Docker, always prefix with `make local`.
+- **Spelling step** uses `npx cspell` and may download cspell on first run (network required).
+- **`make local test` / `scripts/check.sh`** require `golangci-lint` on PATH (`devtools.sh`).
+- As of the current tree, `pkg/yqlib/ini_test.go` calls `NewINIDecoder()` without required `INIPreferences`, which breaks unit-test compilation in `make local check` / `make local test`. The **binary still builds** (`go build -o yq .`) and **all acceptance tests pass** (`bash scripts/acceptance.sh`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 See [agents.md](./agents.md) for contributor workflow (formatting, testing patterns, adding encoders/decoders).
 
+Always run the spellcheck before raising a PR:
+
+```bash
+bash scripts/spelling.sh
+```
+
+This is also included in the full CI pipeline via `make local test`.
+
 ## Cursor Cloud specific instructions
 
 ### Overview
@@ -39,7 +47,7 @@ export PATH="$HOME/go/bin:$PATH"
 
 `make local build` runs the full CI chain (format → spelling → gosec → lint → unit tests → build → acceptance). For a faster loop, build with `go build -o yq .` and run `bash scripts/acceptance.sh`.
 
-### Gotchas
+### Caveats
 
 - **`make` without `local`** tries Docker/Podman (`Dockerfile.dev`). In Cloud Agent VMs without Docker, always prefix with `make local`.
 - **Spelling step** uses `npx cspell` and may download cspell on first run (network required).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the yq CLI codebase, including local (non-Docker) workflows, PATH setup for lint tools, and known gotchas discovered during environment setup.

## Environment verification

- Go 1.25.0 installed; `go mod vendor` succeeds
- `bash scripts/devtools.sh` installs golangci-lint and gosec
- `go build -o yq .` produces working binary (v4.53.2)
- `bash scripts/acceptance.sh` — all acceptance tests pass
- Core yq operations verified: read, transform, merge, format conversion, in-place update

## VM update script

```
go mod download
go mod vendor
bash scripts/devtools.sh
```

## Note

`make local check` / `make local test` currently fail on master due to a compile error in `pkg/yqlib/ini_test.go:206` (`NewINIDecoder()` missing `INIPreferences` argument). Documented in AGENTS.md; binary build and acceptance tests are unaffected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d34eda35-b35c-448d-8a1c-7625b0b169d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d34eda35-b35c-448d-8a1c-7625b0b169d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

