### PR TITLE
fix: reject negative indent instead of panicking

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -87,6 +87,10 @@ func validateCommandFlags(args []string) error {
 		return fmt.Errorf("cannot pass files in when using null-input flag")
 	}
 
+	if indent < 0 {
+		return fmt.Errorf("indent must not be negative")
+	}
+
 	return nil
 }
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1086,6 +1086,7 @@ func TestValidateCommandFlags(t *testing.T) {
 		frontMatter   string
 		splitFileExp  string
 		nullInput     bool
+		indent        int
 		expectError   bool
 		errorContains string
 	}{
@@ -1148,6 +1149,27 @@ func TestValidateCommandFlags(t *testing.T) {
 			expectError:   true,
 			errorContains: "cannot pass files in when using null-input flag",
 		},
+		{
+			name:          "negative indent",
+			args:          []string{"file.yaml"},
+			writeInplace:  false,
+			frontMatter:   "",
+			splitFileExp:  "",
+			nullInput:     false,
+			indent:        -1,
+			expectError:   true,
+			errorContains: "indent must not be negative",
+		},
+		{
+			name:         "zero indent is valid",
+			args:         []string{"file.yaml"},
+			writeInplace: false,
+			frontMatter:  "",
+			splitFileExp: "",
+			nullInput:    false,
+			indent:       0,
+			expectError:  false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1157,17 +1179,20 @@ func TestValidateCommandFlags(t *testing.T) {
 			originalFrontMatter := frontMatter
 			originalSplitFileExp := splitFileExp
 			originalNullInput := nullInput
+			originalIndent := indent
 			defer func() {
 				writeInplace = originalWriteInplace
 				frontMatter = originalFrontMatter
 				splitFileExp = originalSplitFileExp
 				nullInput = originalNullInput
+				indent = originalIndent
 			}()
 
 			writeInplace = tt.writeInplace
 			frontMatter = tt.frontMatter
 			splitFileExp = tt.splitFileExp
 			nullInput = tt.nullInput
+			indent = tt.indent
 
 			err := validateCommandFlags(tt.args)
 			if tt.expectError {


### PR DESCRIPTION
> Generated by an AI agent (Claude Code) acting on the user's behalf, not the user personally.

Fixes #2329.

## the problem

a negative indent crashes yq instead of erroring cleanly:

```
$ echo 'hello: world' | yq -I=-1 '.'
panic: go-yaml dump error in serializer: cannot indent to a negative number of spaces
[stack trace...]
```

the `-I/--indent` flag is an int with no lower bound, so a negative value flows straight through to the yaml encoder's `SetIndent`, which panics. a bad flag value should be a clean error, not a stack trace.

## the fix

reject a negative indent in `validateCommandFlags` (the same place the other flag-combo checks live), before any encoding happens:

```go
if indent < 0 {
    return fmt.Errorf("indent must not be negative")
}
```

after:

```
$ echo 'hello: world' | yq -I=-1 '.'
Error: indent must not be negative      # exit 1, no panic
```

`-I=0` stays valid (it's documented for one-line json), so the guard is `< 0`, not `<= 0`. validating at the flag layer covers every output format at once rather than patching each encoder.

## tests

extended `TestValidateCommandFlags` with a negative case (fails without the guard, passes with it) and a zero case (pins that `-I=0` stays valid). existing cases unaffected.