### PR TITLE
fix: skip UTF-8 BOM when processing front matter

### DIFF
--- a/pkg/yqlib/front_matter.go
+++ b/pkg/yqlib/front_matter.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"os"
+
+	"github.com/dimchansky/utfbom"
 )
 
 type frontMatterHandler interface {
@@ -43,13 +45,15 @@ func (f *frontMatterHandlerImpl) Split() error {
 	var reader *bufio.Reader
 	var err error
 	if f.originalFilename == "-" {
-		reader = bufio.NewReader(os.Stdin)
+		cleanReader, _ := utfbom.Skip(os.Stdin)
+		reader = bufio.NewReader(cleanReader)
 	} else {
 		file, err := os.Open(f.originalFilename) // #nosec
 		if err != nil {
 			return err
 		}
-		reader = bufio.NewReader(file)
+		cleanReader, _ := utfbom.Skip(file)
+		reader = bufio.NewReader(cleanReader)
 	}
 	f.contentReader = reader
 

--- a/pkg/yqlib/front_matter.go
+++ b/pkg/yqlib/front_matter.go
@@ -2,12 +2,25 @@ package yqlib
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"io"
 	"os"
-
-	"github.com/dimchansky/utfbom"
 )
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// stripUTF8BOM returns a reader that skips a leading UTF-8 BOM, if present.
+func stripUTF8BOM(r io.Reader) io.Reader {
+	br := bufio.NewReader(r)
+
+	peek, err := br.Peek(3)
+	if err == nil && bytes.Equal(peek, utf8BOM) {
+		_, _ = br.Discard(3)
+	}
+
+	return br
+}
 
 type frontMatterHandler interface {
 	Split() error
@@ -45,15 +58,13 @@ func (f *frontMatterHandlerImpl) Split() error {
 	var reader *bufio.Reader
 	var err error
 	if f.originalFilename == "-" {
-		cleanReader, _ := utfbom.Skip(os.Stdin)
-		reader = bufio.NewReader(cleanReader)
+		reader = bufio.NewReader(stripUTF8BOM(os.Stdin))
 	} else {
 		file, err := os.Open(f.originalFilename) // #nosec
 		if err != nil {
 			return err
 		}
-		cleanReader, _ := utfbom.Skip(file)
-		reader = bufio.NewReader(cleanReader)
+		reader = bufio.NewReader(stripUTF8BOM(file))
 	}
 	f.contentReader = reader
 

--- a/pkg/yqlib/front_matter_test.go
+++ b/pkg/yqlib/front_matter_test.go
@@ -157,6 +157,42 @@ Some content
 	fmHandler.CleanUp()
 }
 
+func TestFrontMatterSplitWithBOM(t *testing.T) {
+	// Regression test for https://github.com/mikefarah/yq/issues/2496
+	// A UTF-8 BOM before the opening --- must be skipped, otherwise the
+	// separator isn't recognised and the opening --- is lost.
+	file := createTestFile("\ufeff---\na: apple\nb: banana\n---\nnot a\nyaml: doc\n")
+
+	expectedYamlFm := `---
+a: apple
+b: banana
+`
+
+	expectedContent := `---
+not a
+yaml: doc
+`
+
+	fmHandler := NewFrontMatterHandler(file)
+	err := fmHandler.Split()
+	if err != nil {
+		panic(err)
+	}
+
+	yamlFm := readFile(fmHandler.GetYamlFrontMatterFilename())
+
+	test.AssertResult(t, expectedYamlFm, yamlFm)
+
+	contentBytes, err := io.ReadAll(fmHandler.GetContentReader())
+	if err != nil {
+		panic(err)
+	}
+	test.AssertResult(t, expectedContent, string(contentBytes))
+
+	tryRemoveTempFile(file)
+	fmHandler.CleanUp()
+}
+
 func TestFrontMatterSplitWithArray(t *testing.T) {
 	file := createTestFile(`[1,2,3]
 ---

--- a/pkg/yqlib/front_matter_test.go
+++ b/pkg/yqlib/front_matter_test.go
@@ -193,6 +193,56 @@ yaml: doc
 	fmHandler.CleanUp()
 }
 
+func TestFrontMatterSplitWithBOMFromStdin(t *testing.T) {
+	// Regression test for https://github.com/mikefarah/yq/issues/2496
+	// A UTF-8 BOM must also be skipped when reading front matter from stdin.
+	originalStdin := os.Stdin
+	defer func() { os.Stdin = originalStdin }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	os.Stdin = r
+	defer safelyCloseFile(r)
+
+	go func() {
+		_, writeErr := w.WriteString("\ufeff---\na: apple\nb: banana\n---\nnot a\nyaml: doc\n")
+		if writeErr != nil {
+			t.Errorf("failed to write front matter to the stdin pipe: %v", writeErr)
+		}
+		safelyCloseFile(w)
+	}()
+
+	expectedYamlFm := `---
+a: apple
+b: banana
+`
+
+	expectedContent := `---
+not a
+yaml: doc
+`
+
+	fmHandler := NewFrontMatterHandler("-")
+	err = fmHandler.Split()
+	if err != nil {
+		panic(err)
+	}
+
+	yamlFm := readFile(fmHandler.GetYamlFrontMatterFilename())
+
+	test.AssertResult(t, expectedYamlFm, yamlFm)
+
+	contentBytes, err := io.ReadAll(fmHandler.GetContentReader())
+	if err != nil {
+		panic(err)
+	}
+	test.AssertResult(t, expectedContent, string(contentBytes))
+
+	fmHandler.CleanUp()
+}
+
 func TestFrontMatterSplitWithArray(t *testing.T) {
 	file := createTestFile(`[1,2,3]
 ---


### PR DESCRIPTION
> Disclosure: this PR was written by an AI agent (Claude Code) acting on the user's behalf, not the user personally.

## what

`yq --front-matter=process` drops the opening `---` when the input file starts with a UTF-8 BOM, which loses data:

```
$ printf '\xEF\xBB\xBF---\ntitle: Test\n---\n' > test.md
$ yq --front-matter=process test.md
title: Test
---
```

The opening `---` is gone. This is #2496.

## why

`front_matter.go`'s `Split()` wraps the file in a `bufio.Reader` without skipping a leading BOM. The first line read is then `\xEF\xBB\xBF---`, so the `---` separator is not recognised and that line is treated as content instead of the front-matter delimiter.

## fix

Skip the BOM with `utfbom.Skip` before wrapping the reader, the same way `decoder_csv_object.go` already does. `utfbom` is already a direct dependency.

```go
cleanReader, _ := utfbom.Skip(file)
reader = bufio.NewReader(cleanReader)
```

Applied to both the file and stdin paths. `utfbom.Skip` replays non-BOM bytes unchanged, so files without a BOM are byte-identical.

## tests

`TestFrontMatterSplitWithBOM` in `front_matter_test.go` feeds a BOM-prefixed document and asserts the front matter and content split correctly. It fails before the fix (the front matter starts with the BOM) and passes after.

Fixes #2496.
