### PR TITLE
fix(strings): don't halve backslashes in interpolated string literals

### DIFF
--- a/pkg/yqlib/operator_strings.go
+++ b/pkg/yqlib/operator_strings.go
@@ -62,8 +62,14 @@ func interpolate(d *dataTreeNavigator, context Context, str string) (string, err
 					i++
 					continue
 				case '\\':
-					// skip the escaped backslash
-					i++
+					// A backslash pair is only an interpolation escape when it
+					// guards an opening paren ("\\(" -> literal "\("). The lexer
+					// (processEscapeCharacters) has already decoded string escapes,
+					// so a standalone pair must pass through unchanged rather than
+					// be halved a second time (#2561).
+					if i+2 < len(runes) && runes[i+2] == '(' {
+						i++ // skip the second backslash; '(' is emitted as literal text next
+					}
 				default:
 					log.Debugf("Ignoring non-escaping backslash @ %v[%d]", str, i)
 				}

--- a/pkg/yqlib/operator_strings_test.go
+++ b/pkg/yqlib/operator_strings_test.go
@@ -31,6 +31,22 @@ var stringsOperatorScenarios = []expressionScenario{
 	},
 	{
 		skipDoc:     true,
+		description: "Interpolation - backslashes are not halved (#2561)",
+		expression:  `"\\\\"`,
+		expected: []string{
+			"D0, P[], (!!str)::\\\\\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "Interpolation - odd backslash run preserved (#2561)",
+		expression:  `"\\\\\\"`,
+		expected: []string{
+			"D0, P[], (!!str)::\\\\\\\n",
+		},
+	},
+	{
+		skipDoc:     true,
 		description: "Interpolation - nested",
 		document:    `value: things`,
 		expression:  `"Hi \( (.value) )"`,


### PR DESCRIPTION
Fixes #2561.

## What

A string literal in an expression loses half of any run of backslashes, so the value differs from the same string read as input (and from `jq`):

```console
$ yq -Pn -oj '["\\","\\\\","\\\\\\"]'
[ "\\", "\\", "\\\\" ]          # wrong: 1,1,2 backslashes

$ yq -P -oj <<< '["\\","\\\\","\\\\\\"]'
[ "\\", "\\\\", "\\\\\\" ]      # correct: 1,2,3 backslashes
```

## Why

Escapes in an expression string literal are processed twice. The lexer runs `processEscapeCharacters`, which already decodes `\\` -> `\` (while deliberately preserving `\\(` so interpolation escaping survives). `interpolate()` then collapses every remaining backslash pair a second time, halving runs of backslashes.

That second collapse is only needed for the `\\(` -> literal `\(` escape. A standalone pair should pass through untouched. The fix guards the skip on a following `(`, mirroring the special case the lexer already uses, so `\\(` still yields a literal `\(` but plain backslash runs survive.

## Testing

- Two regression scenarios added in `operator_strings_test.go` (`\\\\` and `\\\\\\`); both fail on `master` and pass with the fix.
- Existing interpolation scenarios (`"\\"`, `"Hi \\(.value)"`, real `\(...)` interpolation) still pass unchanged.

Thanks to the reporter for the clear before/after repro.