### PR TITLE
Fix deleting commented empty list YAML output

### DIFF
--- a/pkg/yqlib/operator_delete.go
+++ b/pkg/yqlib/operator_delete.go
@@ -71,6 +71,29 @@ func deleteFromMap(node *CandidateNode, childPath interface{}) {
 	node.Content = newContents
 }
 
+func normaliseEmptySequenceMapKeyComment(node *CandidateNode) {
+	if node.Kind != SequenceNode || len(node.Content) != 0 || node.LineComment != "" {
+		return
+	}
+
+	key := node.Key
+	if node.Parent != nil && node.Parent.Kind == MappingNode {
+		for index := 0; index < len(node.Parent.Content)-1; index += 2 {
+			if node.Parent.Content[index+1] == node {
+				key = node.Parent.Content[index]
+				break
+			}
+		}
+	}
+	if key == nil || key.LineComment == "" {
+		return
+	}
+
+	node.LineComment = key.LineComment
+	key.LineComment = ""
+	node.Style = FlowStyle
+}
+
 func deleteFromArray(node *CandidateNode, childPath interface{}) {
 	log.Debug("deleteFromArray")
 	contents := node.Content
@@ -87,4 +110,5 @@ func deleteFromArray(node *CandidateNode, childPath interface{}) {
 		}
 	}
 	node.Content = newContents
+	normaliseEmptySequenceMapKeyComment(node)
 }

--- a/pkg/yqlib/operator_delete_test.go
+++ b/pkg/yqlib/operator_delete_test.go
@@ -121,6 +121,19 @@ var deleteOperatorScenarios = []expressionScenario{
 	},
 	{
 		skipDoc:     true,
+		description: "Delete all entries from list with inline key comment",
+		document: `testList: # A comment
+- name: test1
+  value: 123
+- name: test2
+  value: 456`,
+		expression: `del(.testList[])`,
+		expected: []string{
+			"D0, P[], (!!map)::testList: [] # A comment\n",
+		},
+	},
+	{
+		skipDoc:     true,
 		description: "Delete entry appended to an array",
 		document:    `[1,2]`,
 		expression:  `. += [3] | del(.[2])`,


### PR DESCRIPTION
> Generated by an AI agent acting on Dustin's behalf, not by Dustin personally.

## Summary
- Fix invalid YAML output when `del(.testList[])` empties a sequence whose mapping key has an inline comment.
- Preserve the inline comment by moving it onto the emptied sequence value and emitting the empty sequence in flow style.
- Add a focused regression test for issue #2600.

Fixes #2600.

## Tests
- `git diff --check`
- `env GOCACHE=/private/tmp/yq-gocache go test ./pkg/yqlib -run TestDeleteOperatorScenarios -count=1`
- `env GOCACHE=/private/tmp/yq-gocache go test ./pkg/yqlib -run 'TestDeleteOperatorScenarios|TestCommentOperatorScenarios|TestStyleOperatorScenarios' -count=1`
- `bash scripts/spelling.sh`
- Manual smoke: ran `go run . 'del(.testList[])'` against the issue-shaped YAML, confirmed `testList: [] # A comment`, and reparsed the output with `go run . '.'`.

## Checks attempted but not completed
- `go test ./pkg/yqlib -count=1` currently fails in unrelated `TestTomlScenarios` because the TOML parser error text differs (`basic string not terminated by "` vs `unterminated basic string`).
