### PR TITLE
fix(unique): ignore comments when comparing array elements

### DIFF
--- a/pkg/yqlib/operator_unique.go
+++ b/pkg/yqlib/operator_unique.go
@@ -66,8 +66,32 @@ func getUniqueKeyValue(rhs Context) (string, error) {
 		keyCandidate := first.Value.(*CandidateNode)
 		keyValue = keyCandidate.Value
 		if keyCandidate.Kind != ScalarNode {
-			keyValue, err = encodeToString(keyCandidate, encoderPreferences{YamlFormat, 0})
+			// Encode a comment-free copy so that uniqueness is decided by the
+			// data only. Otherwise a comment attached to one of two otherwise
+			// equal nodes changes its encoding and they are wrongly kept as
+			// distinct (see #2491).
+			keyValue, err = encodeToString(withoutComments(keyCandidate), encoderPreferences{YamlFormat, 0})
 		}
 	}
 	return keyValue, err
+}
+
+// withoutComments returns a deep copy of the node with all head, line and foot
+// comments removed throughout the tree, so comments do not affect equality.
+func withoutComments(node *CandidateNode) *CandidateNode {
+	clone := node.Copy()
+	clearComments(clone)
+	return clone
+}
+
+func clearComments(node *CandidateNode) {
+	node.HeadComment = ""
+	node.LineComment = ""
+	node.FootComment = ""
+	if node.Key != nil {
+		clearComments(node.Key)
+	}
+	for _, child := range node.Content {
+		clearComments(child)
+	}
 }

--- a/pkg/yqlib/operator_unique_test.go
+++ b/pkg/yqlib/operator_unique_test.go
@@ -59,6 +59,15 @@ var uniqueOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
+		description: "Unique array of objects with a comment between equal items",
+		skipDoc:     true,
+		document:    "- id: 1001\n# Comment\n- id: 1001\n",
+		expression:  `unique`,
+		expected: []string{
+			"D0, P[], (!!seq)::- id: 1001\n",
+		},
+	},
+	{
 		description: "Unique array of arrays",
 		document:    `[[cat,dog], [cat, sheep], [cat,dog]]`,
 		expression:  `unique`,


### PR DESCRIPTION
> Generated by an AI agent (Claude) acting on the user's behalf, not the user personally.

## Problem

`yq 'unique'` keeps duplicate objects when a comment sits between two equal
items:

```yaml
# data1.yml
- id: 1001
# Comment
- id: 1001
```

`yq 'unique' data1.yml` returns both items instead of one. Scalars dedupe
correctly; the problem only affects non-scalar elements, and only when a
comment lands between the equal items.

## Root cause

`getUniqueKeyValue` (`pkg/yqlib/operator_unique.go`) builds the dedup key for
non-scalar elements by encoding them to YAML:

```go
keyValue, err = encodeToString(keyCandidate, encoderPreferences{YamlFormat, 0})
```

The encoded form includes the node's head/line/foot comments. The `# Comment`
attaches to one of the two equal nodes, so their encodings differ and they are
treated as distinct. Scalars use `.Value` directly, which is why they were
unaffected.

## Fix

Encode a comment-free deep copy of the node for the key, so uniqueness depends
on the data only.

## Test

Added a scenario to `operator_unique_test.go` for the comment-between-equal-items
case. It fails before the change (both items kept) and passes after (deduped to
one). `go test ./pkg/yqlib -run TestUniqueOperatorScenarios`, gofmt, `go vet`,
golangci-lint and `scripts/spelling.sh` are clean for the change.

Fixes #2491
