### PR TITLE
[bugfix] Toml comment roundtrip fixes

### DIFF
--- a/pkg/yqlib/decoder_toml.go
+++ b/pkg/yqlib/decoder_toml.go
@@ -157,9 +157,25 @@ func (dec *tomlDecoder) createInlineTableMap(tomlNode *toml.Node) (*CandidateNod
 	}, nil
 }
 
+// commentIsOnNewLine reports whether comment begins on a line after the end of
+// prev, by scanning the raw input bytes between them for a newline. When the
+// range cannot be determined it returns true, preserving the historic behaviour
+// of treating in-array comments as head comments for the next element.
+func (dec *tomlDecoder) commentIsOnNewLine(prev, comment *toml.Node) bool {
+	prevEnd := prev.Raw.Offset + prev.Raw.Length
+	commentStart := comment.Raw.Offset
+	if commentStart < prevEnd {
+		return true
+	}
+	between := dec.parser.Raw(toml.Range{Offset: prevEnd, Length: commentStart - prevEnd})
+	return bytes.IndexByte(between, '\n') >= 0
+}
+
 func (dec *tomlDecoder) createArray(tomlNode *toml.Node) (*CandidateNode, error) {
 	content := make([]*CandidateNode, 0)
 	var pendingArrayComments []string
+	var prevElem *toml.Node
+	var prevYamlNode *CandidateNode
 
 	iterator := tomlNode.Children()
 	for iterator.Next() {
@@ -167,8 +183,19 @@ func (dec *tomlDecoder) createArray(tomlNode *toml.Node) (*CandidateNode, error)
 
 		// Handle comments within arrays
 		if child.Kind == toml.Comment {
-			// Collect comments to attach to the next array element
-			pendingArrayComments = append(pendingArrayComments, string(child.Data))
+			// A comment on the same line as the preceding element is a trailing
+			// (inline) comment on that element; a comment on its own line is a
+			// head comment for the next element.
+			if prevYamlNode != nil && !dec.commentIsOnNewLine(prevElem, child) {
+				if prevYamlNode.LineComment == "" {
+					prevYamlNode.LineComment = string(child.Data)
+				} else {
+					prevYamlNode.LineComment = prevYamlNode.LineComment + "\n" + string(child.Data)
+				}
+			} else {
+				// Collect comments to attach to the next array element
+				pendingArrayComments = append(pendingArrayComments, string(child.Data))
+			}
 			continue
 		}
 
@@ -184,6 +211,8 @@ func (dec *tomlDecoder) createArray(tomlNode *toml.Node) (*CandidateNode, error)
 		}
 
 		content = append(content, yamlNode)
+		prevElem = child
+		prevYamlNode = yamlNode
 	}
 
 	return &CandidateNode{

--- a/pkg/yqlib/encoder_toml.go
+++ b/pkg/yqlib/encoder_toml.go
@@ -677,7 +677,7 @@ func (te *tomlEncoder) colorizeToml(input []byte) []byte {
 
 		// Table sections - [section] or [[array]]
 		// Only treat '[' as a table section if it appears at the start of the line
-        // (possibly after whitespace). This avoids incorrectly colouring inline arrays like
+		// (possibly after whitespace). This avoids incorrectly colouring inline arrays like
 		// "ports = [8000, 8001]" as table sections.
 		if ch == '[' {
 			isSectionHeader := true

--- a/pkg/yqlib/encoder_toml.go
+++ b/pkg/yqlib/encoder_toml.go
@@ -188,6 +188,10 @@ func (te *tomlEncoder) encodeTopLevelEntry(w io.Writer, path []string, node *Can
 				te.wroteRootAttr = false
 			}
 			for _, it := range node.Content {
+				// Write head comment before the array-of-tables header
+				if err := te.writeComment(w, it.HeadComment); err != nil {
+					return err
+				}
 				if _, err := w.Write([]byte("[[" + quotedKey + "]]\n")); err != nil {
 					return err
 				}
@@ -283,10 +287,10 @@ func (te *tomlEncoder) writeArrayAttribute(w io.Writer, key string, seq *Candida
 		return err
 	}
 
-	// Check if any array elements have head comments - if so, use multiline format
+	// Check if any array elements have head or line comments - if so, use multiline format
 	hasElementComments := false
 	for _, it := range seq.Content {
-		if it.HeadComment != "" {
+		if it.HeadComment != "" || it.LineComment != "" {
 			hasElementComments = true
 			break
 		}
@@ -299,6 +303,13 @@ func (te *tomlEncoder) writeArrayAttribute(w io.Writer, key string, seq *Candida
 		}
 
 		for i, it := range seq.Content {
+			// Separate a head-commented element from the previous one with a blank line
+			if i > 0 && it.HeadComment != "" {
+				if _, err := w.Write([]byte("\n")); err != nil {
+					return err
+				}
+			}
+
 			// Write head comment for this element
 			if it.HeadComment != "" {
 				commentLines := strings.Split(it.HeadComment, "\n")
@@ -340,15 +351,17 @@ func (te *tomlEncoder) writeArrayAttribute(w io.Writer, key string, seq *Candida
 			// Always add trailing comma in multiline arrays
 			itemStr += ","
 
-			if _, err := w.Write([]byte("  " + itemStr + "\n")); err != nil {
-				return err
+			// Append trailing (inline) comment on the same line, if present
+			if it.LineComment != "" {
+				lineComment := strings.TrimSpace(it.LineComment)
+				if !strings.HasPrefix(lineComment, "#") {
+					lineComment = "# " + lineComment
+				}
+				itemStr += "  " + lineComment
 			}
 
-			// Add blank line between elements (except after the last one)
-			if i < len(seq.Content)-1 {
-				if _, err := w.Write([]byte("\n")); err != nil {
-					return err
-				}
+			if _, err := w.Write([]byte("  " + itemStr + "\n")); err != nil {
+				return err
 			}
 		}
 
@@ -546,6 +559,10 @@ func (te *tomlEncoder) encodeSeparateMapping(w io.Writer, path []string, m *Cand
 					te.wroteRootAttr = false
 				}
 				for _, it := range v.Content {
+					// Write head comment before the array-of-tables header
+					if err := te.writeComment(w, it.HeadComment); err != nil {
+						return err
+					}
 					if _, err := w.Write([]byte("[[" + key + "]]\n")); err != nil {
 						return err
 					}
@@ -603,6 +620,10 @@ func (te *tomlEncoder) encodeMappingBodyWithPath(w io.Writer, path []string, m *
 			if isTomlArrayOfTables(v) {
 				dotted := tomlDottedKey(append(append([]string{}, path...), k))
 				for _, it := range v.Content {
+					// Write head comment before the array-of-tables header
+					if err := te.writeComment(w, it.HeadComment); err != nil {
+						return err
+					}
 					if _, err := w.Write([]byte("[[" + dotted + "]]\n")); err != nil {
 						return err
 					}

--- a/pkg/yqlib/toml_test.go
+++ b/pkg/yqlib/toml_test.go
@@ -369,7 +369,7 @@ var tomlScenarios = []formatScenario{
 		skipDoc:       true,
 		description:   "blank",
 		input:         `A = "hello`,
-		expectedError: `bad file 'sample.yml': basic string not terminated by "`,
+		expectedError: `bad file 'sample.yml': unterminated basic string`,
 		scenarioType:  "decode-error",
 	},
 	{

--- a/pkg/yqlib/toml_test.go
+++ b/pkg/yqlib/toml_test.go
@@ -325,6 +325,33 @@ the_array = [
 ]
 `
 
+// Bug: a head comment directly above an [[array-of-tables]] header is dropped
+// on round-trip when other content precedes the array-of-tables.
+var rtArrayTableHeadComment = `[package]
+name = "x"
+
+# the binary
+[[bin]]
+name = "y"
+`
+
+// Same bug via a nested array-of-tables ([[a.b]]) under a table with attributes.
+var rtNestedArrayTableHeadComment = `[fruit]
+name = "apple"
+# a variety
+[[fruit.variety]]
+name = "red delicious"
+`
+
+// Bug: an inline (trailing) comment on an array item detaches from its item and
+// floats onto its own line as a head comment on the next item, with a spurious
+// blank line.
+var rtArrayItemInlineComment = `default = [
+  "a",  # why a
+  "b",
+]
+`
+
 var expectedSubArrays = `array:
   - subarray:
       - subsubarray:
@@ -698,6 +725,30 @@ var tomlScenarios = []formatScenario{
 		skipDoc:      true,
 		input:        tomlTableWithComments,
 		expected:     tomlTableWithComments,
+		scenarioType: "roundtrip",
+	},
+	{
+		skipDoc:      true,
+		description:  "Roundtrip: head comment above array-of-tables",
+		input:        rtArrayTableHeadComment,
+		expression:   ".",
+		expected:     rtArrayTableHeadComment,
+		scenarioType: "roundtrip",
+	},
+	{
+		skipDoc:      true,
+		description:  "Roundtrip: head comment above nested array-of-tables",
+		input:        rtNestedArrayTableHeadComment,
+		expression:   ".",
+		expected:     rtNestedArrayTableHeadComment,
+		scenarioType: "roundtrip",
+	},
+	{
+		skipDoc:      true,
+		description:  "Roundtrip: inline comment on array item",
+		input:        rtArrayItemInlineComment,
+		expression:   ".",
+		expected:     rtArrayItemInlineComment,
 		scenarioType: "roundtrip",
 	},
 	// Encode (YAML → TOML) scenarios - verify readable table sections are produced


### PR DESCRIPTION
This is _generally_ a simple bugfix. I'm happy to open an issue for discussion, if you like, but it came up when editing some Cargo.tomls, so I worked up a quick fix.

## What

Fixes two TOML comment-fidelity bugs in the round-trip / `-i` path, found while
migrating some `sed`-on-`Cargo.toml` edits to yq.

### 1. Head comment above `[[array-of-tables]]` was dropped

Given:

```toml
[package]
name = "x"

# the binary
[[bin]]
name = "y"
```

`yq -p toml -o toml '.' file.toml` (or any `-i` edit) dropped `# the binary`.
Head comments on ordinary `[table]` headers already survived. The decoder
attaches the comment correctly, but the three encoder loops that emit `[[...]]`
headers never wrote it (unlike the `[table]` path). They do now.

### 2. Inline comment on an array item detached

Given:

```toml
default = [
  "a",  # why a
  "b",
]
```

round-tripped to:

```toml
default = [
  "a",

  # why a
  "b",
]
```

The decoder attached every in-array comment as a head comment on the *next*
element. A trailing comment on the same line as an item is now detected via the
parser's byte ranges and kept as a line comment on that item. The encoder emits
array-item line comments inline and only inserts a blank line before
head-commented elements, so the existing head-comment array layout is unchanged.

## Note

The first commit is two unrelated, pre-existing repairs kept separate from the
comment work (happy to split into their own PR if you'd prefer):

- The go-toml v2.4.2 bump (#2762) renamed the single-line unterminated-string
  error, but the decode-error test still asserted the old message, so
  `TestTomlScenarios` was already failing on `master`.
- A stray `gofmt` fix (a comment line in `encoder_toml.go` was space-indented).

## Tests

Round-trip tests added for both cases in `toml_test.go` (top-level and nested
arrays of tables, plus the inline array-item comment). `go test ./pkg/yqlib/
-run Toml` passes.
