### PR TITLE
fix(has): return false for negative array indices

### DIFF
--- a/pkg/yqlib/operator_has.go
+++ b/pkg/yqlib/operator_has.go
@@ -44,7 +44,7 @@ func hasOperator(d *dataTreeNavigator, context Context, expressionNode *Expressi
 				if errParsingInt != nil {
 					return Context{}, errParsingInt
 				}
-				candidateHasKey = int64(len(contents)) > number
+				candidateHasKey = number >= 0 && int64(len(contents)) > number
 			}
 			results.PushBack(createBooleanCandidate(candidate, candidateHasKey))
 		default:

--- a/pkg/yqlib/operator_has_test.go
+++ b/pkg/yqlib/operator_has_test.go
@@ -71,6 +71,16 @@ var hasOperatorScenarios = []expressionScenario{
 			"D0, P[4], (!!bool)::true\n",
 		},
 	},
+	{
+		skipDoc:     true,
+		description: "Negative array index is never present",
+		document:    "[[1, 2, 3], []]",
+		expression:  `.[] | has(-1)`,
+		expected: []string{
+			"D0, P[0], (!!bool)::false\n",
+			"D0, P[1], (!!bool)::false\n",
+		},
+	},
 }
 
 func TestHasOperatorScenarios(t *testing.T) {


### PR DESCRIPTION
> **Note:** this PR was prepared by an AI agent (Claude Code) acting on behalf of @maximilize, not by the user personally.

## what

`has(-1)` (or any negative index) returns `true` on a sequence, even for an empty array:

```sh
echo '[[1,2,3], []]' | yq '.[] | has(-1)'
# before: true / true
# after:  false / false
```

## why

The sequence branch of `hasOperator` (`pkg/yqlib/operator_has.go`) only checks the upper bound:

```go
candidateHasKey = int64(len(contents)) > number
```

For a negative `number` this is always true (`len > -1`). A negative index is never a valid array index: jq returns `false`, and `has.md` documents array `has` as jq-style index existence.

## fix

Also guard the lower bound: `number >= 0 && int64(len(contents)) > number`. Regression scenario added to `operator_has_test.go` (`skipDoc`).
