### PR TITLE
fix(strings): ignore unnamed capture groups

### DIFF
--- a/pkg/yqlib/operator_strings.go
+++ b/pkg/yqlib/operator_strings.go
@@ -365,8 +365,14 @@ func capture(matchPrefs matchPreferences, regEx *regexp.Regexp, candidate *Candi
 
 		_, submatches := matches[0], matches[1:]
 		for j, submatch := range submatches {
-
-			keyNode := createScalarNode(subNames[j+1], subNames[j+1])
+			name := subNames[j+1]
+			// jq only returns named capture groups; unnamed groups (whose
+			// SubexpNames entry is "") must be skipped so they don't become
+			// map entries with an empty-string key.
+			if name == "" {
+				continue
+			}
+			keyNode := createScalarNode(name, name)
 			var valueNode *CandidateNode
 
 			offset := allIndices[i][2+j*2]

--- a/pkg/yqlib/operator_strings_test.go
+++ b/pkg/yqlib/operator_strings_test.go
@@ -364,6 +364,15 @@ var stringsOperatorScenarios = []expressionScenario{
 			"D0, P[], (!!seq)::[\"1\", \"true\", \"null\", \"~\", cat, \"{an: object}\", \"[array, 2]\"]\n",
 		},
 	},
+	{
+		skipDoc:     true,
+		description: "Capture ignores unnamed groups",
+		document:    `foobar`,
+		expression:  `capture("(foo)(?P<rest>bar)")`,
+		expected: []string{
+			"D0, P[], (!!map)::rest: bar\n",
+		},
+	},
 }
 
 func TestStringsOperatorScenarios(t *testing.T) {


### PR DESCRIPTION
> **Note:** this PR was prepared by an AI agent (Claude Code) acting on behalf of @maximilize, not by the user personally.

## what

`capture` emits unnamed regex groups as a map entry with an empty-string key, and produces duplicate empty keys when there are several:

```sh
echo 'foobar' | yq 'capture("(foo)(?P<rest>bar)")'
# before: '"": foo' then 'rest: bar'
# after:  'rest: bar'
```

Two unnamed groups (`capture("(a)(b)")` on `ab`) yield a mapping with two identical `""` keys.

## why

`capture` (`pkg/yqlib/operator_strings.go`) iterates over every submatch and unconditionally builds a key from `regEx.SubexpNames()`, which is `""` for unnamed groups. jq only returns named capture groups, and `string-operators.md` documents capture as returning "named RegEx capture groups in a map".

## fix

Skip submatches whose name is empty, matching jq. Regression scenario added (`skipDoc`).
