### PR TITLE
fix(sort): avoid int64 overflow comparing large integers

### DIFF
--- a/pkg/yqlib/operator_sort.go
+++ b/pkg/yqlib/operator_sort.go
@@ -166,7 +166,12 @@ func (a sortableNodeArray) compare(lhs *CandidateNode, rhs *CandidateNode, dateT
 		if err != nil {
 			panic(err)
 		}
-		return int(lhsNum - rhsNum)
+		if lhsNum < rhsNum {
+			return -1
+		} else if lhsNum > rhsNum {
+			return 1
+		}
+		return 0
 	} else if (lhsTag == "!!int" || lhsTag == "!!float") && (rhsTag == "!!int" || rhsTag == "!!float") {
 		lhsNum, err := strconv.ParseFloat(lhs.Value, 64)
 		if err != nil {

--- a/pkg/yqlib/operator_sort_test.go
+++ b/pkg/yqlib/operator_sort_test.go
@@ -171,6 +171,15 @@ var sortByOperatorScenarios = []expressionScenario{
 			"D0, P[], (!!seq)::# abc\n- def\n# ghi\n",
 		},
 	},
+	{
+		skipDoc:     true,
+		description: "Sort large integers (no int64 subtraction overflow)",
+		document:    "[5000000000000000000, -5000000000000000000]",
+		expression:  `sort`,
+		expected: []string{
+			"D0, P[], (!!seq)::[-5000000000000000000, 5000000000000000000]\n",
+		},
+	},
 }
 
 func TestSortByOperatorScenarios(t *testing.T) {


### PR DESCRIPTION
> **Note:** this PR was prepared by an AI agent (Claude Code) acting on behalf of @maximilize, not by the user personally.

## what

`sort` orders large-magnitude integers incorrectly:

```sh
echo '[5000000000000000000, -5000000000000000000]' | yq 'sort' -o=json -I=0
# before: [5000000000000000000,-5000000000000000000]  (unsorted)
# after:  [-5000000000000000000,5000000000000000000]
```

## why

The int/int branch of the sort comparator (`pkg/yqlib/operator_sort.go`) returns `int(lhsNum - rhsNum)`. The subtraction is done in `int64` and overflows when the difference exceeds the int64 range (`5e18 - (-5e18) = 1e19` wraps negative), so the comparator reports the wrong sign.

## fix

Compare directly (`<` / `>`) instead of subtracting, mirroring the float branch just below. Regression scenario added (`skipDoc`).
