### PR TITLE
Default to yaml when a file's extension is not a recognised format

### DIFF
--- a/pkg/yqlib/format.go
+++ b/pkg/yqlib/format.go
@@ -128,8 +128,11 @@ func FormatStringFromFilename(filename string) string {
 		ext := filepath.Ext(filename)
 		if len(ext) >= 2 && ext[0] == '.' {
 			format := strings.ToLower(ext[1:])
-			GetLogger().Debugf("detected format '%s'", format)
-			return format
+			if _, err := FormatFromString(format); err == nil {
+				GetLogger().Debugf("detected format '%s'", format)
+				return format
+			}
+			GetLogger().Debugf("extension '%s' is not a recognised format, defaulting to yaml", format)
 		}
 	}
 

--- a/pkg/yqlib/format_test.go
+++ b/pkg/yqlib/format_test.go
@@ -59,4 +59,7 @@ func TestFormatStringFromFilename(t *testing.T) {
 	test.AssertResult(t, "json", FormatStringFromFilename("TEST.JSON"))
 	test.AssertResult(t, "yaml", FormatStringFromFilename("test.json/foo"))
 	test.AssertResult(t, "yaml", FormatStringFromFilename(""))
+	// unrecognised extensions should default to yaml instead of being passed through verbatim
+	// (see https://github.com/mikefarah/yq/issues/1608)
+	test.AssertResult(t, "yaml", FormatStringFromFilename("test.tfstate"))
 }


### PR DESCRIPTION
## Summary

`FormatStringFromFilename` (in `pkg/yqlib/format.go`) auto-detects the input/output format from a file's extension. If the extension isn't one yq recognises (e.g. `.tfstate`, as in a real-world Terraform state file), it currently returns the raw extension string unchanged. That string then fails in `FormatFromString` with `unknown format 'tfstate' please use [...]`, instead of falling back to YAML the way it does when there's no extension at all.

This was flagged by @mikefarah directly in #1608:

> I think that's a bug in the new behaviour, and should be a separate issue so I can resolve it separately to this - if it doesn't recognise the extension I should just make it default to yaml. I'll fix that ASAP.

That follow-up fix doesn't appear to have landed - the current `master` still returns the raw unrecognised extension.

## Change

`FormatStringFromFilename` now checks the detected extension against the known `Formats` list (reusing the existing `FormatFromString`/`MatchesName` logic) before returning it. If the extension isn't recognised, it falls through to the existing `"yaml"` default instead of returning the raw string.

No behavior changes for any recognised extension (`.yaml`, `.json`, `.csv`, etc.) - only unrecognised extensions are affected, and their new behavior (default to yaml) matches what the maintainer described as intended.

## Testing

Added a case to `TestFormatStringFromFilename` in `pkg/yqlib/format_test.go` covering the exact scenario from the issue (`test.tfstate` -> `"yaml"`). All existing cases in that test (recognised extensions, no extension, empty filename, path with no extension on the last segment) continue to pass unchanged.

Closes #1608