### PR TITLE
Fix missing keys being dropped from collects in read-only contexts

### DIFF
--- a/pkg/yqlib/context.go
+++ b/pkg/yqlib/context.go
@@ -31,7 +31,7 @@ func (n *Context) SingleChildContext(candidate *CandidateNode) Context {
 
 // CollectingChildContext evaluates a collect expression without allowing a
 // read-only parent context to suppress missing-key nulls. Missing values are
-// materialized by traversal without being added to a read-only input node.
+// materialised by traversal without being added to a read-only input node.
 func (n *Context) CollectingChildContext(candidate *CandidateNode) Context {
 	newContext := n.SingleChildContext(candidate)
 	newContext.AutoCreateOnMissing = true
@@ -39,7 +39,7 @@ func (n *Context) CollectingChildContext(candidate *CandidateNode) Context {
 }
 
 // CollectingReadonlyChildContext is CollectingChildContext with the read-only
-// flag forced: missing keys materialize as detached nulls and the input node
+// flag forced: missing keys materialise as detached nulls and the input node
 // is never modified. Used when collecting over documents that must not gain
 // auto-created keys (e.g. collect-together over multiple documents).
 func (n *Context) CollectingReadonlyChildContext(candidate *CandidateNode) Context {
@@ -123,7 +123,7 @@ func (n *Context) Clone() Context {
 func (n *Context) ReadOnlyClone() Context {
 	clone := n.Clone()
 	clone.DontAutoCreate = true
-	// a read-only lookup wants existing nodes only: never materialize
+	// a read-only lookup wants existing nodes only: never materialise
 	// missing-key nulls here, even inside a collect (see CollectingChildContext)
 	clone.AutoCreateOnMissing = false
 	return clone

--- a/pkg/yqlib/context.go
+++ b/pkg/yqlib/context.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Context struct {
-	MatchingNodes  *list.List
-	Variables      map[string]*list.List
-	DontAutoCreate bool
-	datetimeLayout string
+	MatchingNodes       *list.List
+	Variables           map[string]*list.List
+	DontAutoCreate      bool
+	AutoCreateOnMissing bool
+	datetimeLayout      string
 }
 
 func (n *Context) SingleReadonlyChildContext(candidate *CandidateNode) Context {
@@ -26,6 +27,25 @@ func (n *Context) SingleChildContext(candidate *CandidateNode) Context {
 	list := list.New()
 	list.PushBack(candidate)
 	return n.ChildContext(list)
+}
+
+// CollectingChildContext evaluates a collect expression without allowing a
+// read-only parent context to suppress missing-key nulls. Missing values are
+// materialized by traversal without being added to a read-only input node.
+func (n *Context) CollectingChildContext(candidate *CandidateNode) Context {
+	newContext := n.SingleChildContext(candidate)
+	newContext.AutoCreateOnMissing = true
+	return newContext
+}
+
+// CollectingReadonlyChildContext is CollectingChildContext with the read-only
+// flag forced: missing keys materialize as detached nulls and the input node
+// is never modified. Used when collecting over documents that must not gain
+// auto-created keys (e.g. collect-together over multiple documents).
+func (n *Context) CollectingReadonlyChildContext(candidate *CandidateNode) Context {
+	newContext := n.SingleReadonlyChildContext(candidate)
+	newContext.AutoCreateOnMissing = true
+	return newContext
 }
 
 func (n *Context) SetDateTimeLayout(newDateTimeLayout string) {
@@ -54,7 +74,11 @@ func (n *Context) SetVariable(name string, value *list.List) {
 }
 
 func (n *Context) ChildContext(results *list.List) Context {
-	clone := Context{DontAutoCreate: n.DontAutoCreate, datetimeLayout: n.datetimeLayout}
+	clone := Context{
+		DontAutoCreate:      n.DontAutoCreate,
+		AutoCreateOnMissing: n.AutoCreateOnMissing,
+		datetimeLayout:      n.datetimeLayout,
+	}
 	clone.Variables = make(map[string]*list.List)
 	for variableKey, originalValueList := range n.Variables {
 
@@ -99,6 +123,9 @@ func (n *Context) Clone() Context {
 func (n *Context) ReadOnlyClone() Context {
 	clone := n.Clone()
 	clone.DontAutoCreate = true
+	// a read-only lookup wants existing nodes only: never materialize
+	// missing-key nulls here, even inside a collect (see CollectingChildContext)
+	clone.AutoCreateOnMissing = false
 	return clone
 }
 

--- a/pkg/yqlib/operator_booleans_test.go
+++ b/pkg/yqlib/operator_booleans_test.go
@@ -6,6 +6,26 @@ import (
 
 var booleanOperatorScenarios = []expressionScenario{
 	{
+		// https://github.com/mikefarah/yq/issues/2782
+		skipDoc:     true,
+		description: "Or with collected missing key",
+		document:    `{}`,
+		expression:  `false or ([.a] | length == 1)`,
+		expected: []string{
+			"D0, P[], (!!bool)::true\n",
+		},
+	},
+	{
+		// https://github.com/mikefarah/yq/issues/2782
+		skipDoc:     true,
+		description: "And with collected missing key",
+		document:    `{}`,
+		expression:  `true and ([.a] | length == 1)`,
+		expected: []string{
+			"D0, P[], (!!bool)::true\n",
+		},
+	},
+	{
 		description: "`or` example",
 		expression:  `true or false`,
 		expected: []string{

--- a/pkg/yqlib/operator_collect.go
+++ b/pkg/yqlib/operator_collect.go
@@ -8,7 +8,7 @@ func collectTogether(d *dataTreeNavigator, context Context, expressionNode *Expr
 	collectedNode := &CandidateNode{Kind: SequenceNode, Tag: "!!seq"}
 	for el := context.MatchingNodes.Front(); el != nil; el = el.Next() {
 		candidate := el.Value.(*CandidateNode)
-		collectExpResults, err := d.GetMatchingNodes(context.SingleReadonlyChildContext(candidate), expressionNode)
+		collectExpResults, err := d.GetMatchingNodes(context.CollectingReadonlyChildContext(candidate), expressionNode)
 		if err != nil {
 			return nil, err
 		}
@@ -56,7 +56,7 @@ func collectOperator(d *dataTreeNavigator, context Context, expressionNode *Expr
 
 		log.Debugf("collect rhs: %v", expressionNode.RHS.Operation.toString())
 
-		collectExpResults, err := d.GetMatchingNodes(context.SingleChildContext(candidate), expressionNode.RHS)
+		collectExpResults, err := d.GetMatchingNodes(context.CollectingChildContext(candidate), expressionNode.RHS)
 		if err != nil {
 			return Context{}, err
 		}

--- a/pkg/yqlib/operator_collect_test.go
+++ b/pkg/yqlib/operator_collect_test.go
@@ -6,6 +6,18 @@ import (
 
 var collectOperatorScenarios = []expressionScenario{
 	{
+		// https://github.com/mikefarah/yq/issues/2782: collects in read-only
+		// contexts materialize missing keys as nulls (jq-aligned) without
+		// modifying the input
+		skipDoc:     true,
+		description: "Assign collect of missing key",
+		document:    `{a: 1}`,
+		expression:  `.result = [.missing]`,
+		expected: []string{
+			"D0, P[], (!!map)::{a: 1, result: [null]}\n",
+		},
+	},
+	{
 		skipDoc:    true,
 		expression: `["x", "y"] | .[1]`,
 		expected: []string{

--- a/pkg/yqlib/operator_collect_test.go
+++ b/pkg/yqlib/operator_collect_test.go
@@ -7,7 +7,7 @@ import (
 var collectOperatorScenarios = []expressionScenario{
 	{
 		// https://github.com/mikefarah/yq/issues/2782: collects in read-only
-		// contexts materialize missing keys as nulls (jq-aligned) without
+		// contexts materialise missing keys as nulls (jq-aligned) without
 		// modifying the input
 		skipDoc:     true,
 		description: "Assign collect of missing key",

--- a/pkg/yqlib/operator_delete_test.go
+++ b/pkg/yqlib/operator_delete_test.go
@@ -6,6 +6,26 @@ import (
 
 var deleteOperatorScenarios = []expressionScenario{
 	{
+		// https://github.com/mikefarah/yq/issues/2782 follow-up: a collect
+		// wrapping a delete of a missing key must not panic
+		skipDoc:     true,
+		description: "Collect delete of missing key",
+		document:    `a: 1`,
+		expression:  `[del(.b)]`,
+		expected: []string{
+			"D0, P[], (!!seq)::- a: 1\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "Select over collect delete of missing key",
+		document:    `a: 1`,
+		expression:  `select([del(.b)] | length == 1)`,
+		expected: []string{
+			"D0, P[], (!!map)::a: 1\n",
+		},
+	},
+	{
 		description: "Delete entry in map",
 		document:    `{a: cat, b: dog}`,
 		expression:  `del(.b)`,

--- a/pkg/yqlib/operator_select_test.go
+++ b/pkg/yqlib/operator_select_test.go
@@ -12,6 +12,39 @@ var selectOperatorScenarios = []expressionScenario{
 		expected:   []string{},
 	},
 	{
+		// https://github.com/mikefarah/yq/issues/2782
+		skipDoc:     true,
+		description: "Select with collected missing key",
+		document:    `{}`,
+		expression:  `select([.a] | length == 1)`,
+		expected: []string{
+			"D0, P[], (!!map)::{}\n",
+		},
+	},
+	{
+		// child-node input: the scenario harness evaluates documents
+		// together, so this is what pins the streaming (collectOperator)
+		// path that the CLI default and `yq -n` actually run
+		skipDoc:     true,
+		description: "Select with collected missing key on child node",
+		document:    `{a: {}}`,
+		expression:  `.a | select([.b] | length == 1)`,
+		expected: []string{
+			"D0, P[a], (!!map)::{}\n",
+		},
+	},
+	{
+		// collecting a path under an existing null must not mutate the
+		// input (the null-kind guess used to flip it to a map in place)
+		skipDoc:     true,
+		description: "Select with collected key under existing null",
+		document:    `{a: null}`,
+		expression:  `select([.a.b] | length == 1)`,
+		expected: []string{
+			"D0, P[], (!!map)::{a: null}\n",
+		},
+	},
+	{
 		skipDoc:    true,
 		document:   `cat`,
 		expression: `select(false, true)`,

--- a/pkg/yqlib/operator_traverse_path.go
+++ b/pkg/yqlib/operator_traverse_path.go
@@ -63,8 +63,13 @@ func traverse(context Context, matchingNode *CandidateNode, operation *Operation
 		return nil, err
 	}
 
-	if matchingNode.Tag == "!!null" && operation.Value != "[]" && !context.DontAutoCreate {
+	if matchingNode.Tag == "!!null" && operation.Value != "[]" && (!context.DontAutoCreate || context.AutoCreateOnMissing) {
 		log.Debugf("Guessing kind")
+		if context.DontAutoCreate {
+			// collecting from a read-only context: guess the kind on a
+			// detached copy so the original null is not mutated in place.
+			matchingNode = matchingNode.Copy()
+		}
 		// we must have added this automatically, lets guess what it should be now
 		switch operation.Value.(type) {
 		case int, int64:
@@ -260,25 +265,31 @@ func traverseMap(context Context, matchingNode *CandidateNode, keyNode *Candidat
 		return nil, err
 	}
 
-	if !splat && !prefs.DontAutoCreate && !context.DontAutoCreate && newMatches.Len() == 0 {
+	if !splat && !prefs.DontAutoCreate && (!context.DontAutoCreate || context.AutoCreateOnMissing) && newMatches.Len() == 0 {
 		log.Debugf("no matches, creating one for %v", NodeToString(keyNode))
-		//no matches, create one automagically
 		valueNode := matchingNode.CreateChild()
 		valueNode.Kind = ScalarNode
 		valueNode.Tag = "!!null"
 		valueNode.Value = "null"
 
-		if len(matchingNode.Content) == 0 {
-			matchingNode.Style = 0
-		}
-
-		keyNode, valueNode = matchingNode.AddKeyValueChild(keyNode, valueNode)
-
-		if prefs.IncludeMapKeys {
-			newMatches.Set(keyNode.GetKey(), keyNode)
-		}
-		if !prefs.DontIncludeMapValues {
+		if context.DontAutoCreate {
+			// A collect expression needs a concrete null for a missing key, but
+			// must not add that key to the read-only node being collected from.
 			newMatches.Set(valueNode.GetKey(), valueNode)
+		} else {
+			if len(matchingNode.Content) == 0 {
+				// default to nice yaml formatting
+				matchingNode.Style = 0
+			}
+
+			keyNode, valueNode = matchingNode.AddKeyValueChild(keyNode, valueNode)
+
+			if prefs.IncludeMapKeys {
+				newMatches.Set(keyNode.GetKey(), keyNode)
+			}
+			if !prefs.DontIncludeMapValues {
+				newMatches.Set(valueNode.GetKey(), valueNode)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #2782.

Collecting a missing key gives `[null]` at the top level, but inside `select`/`and`/`or` the key was dropped entirely:

```
yq -n '{} | ([.a] | length)'                 # 1
yq -n '{} | select([.a] | length == 1)'      # no output, expected {}
yq -n '{} | (true and ([.a] | length == 1))' # false, expected true
```

jq returns the document / `true` for these.

Cause: `select` and the boolean operators evaluate their operands in read-only contexts (`DontAutoCreate`), so traversing a missing key emits nothing and the collect builds `[]` instead of `[null]`.

Change: collects now evaluate their inner expression with a context that materializes a missing key as a detached null. The collected array gets its `[null]` and the input document does not gain the key. Read-only lookups that only want existing nodes, like the one `del` uses to find its target, explicitly opt out. An existing null in the path is copied before the traversal guesses its kind, so `{a: null}` stays `{a: null}` instead of becoming `{a: {}}`.

Scope note: collects in other read-only evaluations now match jq as well. `.result = [.missing]` produces `result: [null]` (was `result: []`), and `yq ea '[.a]'` over docs `{a: 1}` and `{b: 2}` produces `[1, null]` (was `[1]`). Input documents come through unchanged in all of these cases. One pre-existing behavior is deliberately untouched: array index traversal on an existing null (`.a[0]` with `a: null`) still auto-vivifies the null into an array, exactly as on master.

The regression scenarios cover select/and/or, `del` of a missing key inside a collect (which must not panic), collecting under an existing null, the assignment case, and a child-node case that pins the streaming evaluator path the CLI uses (the test harness evaluates documents together, which routes collects differently).

For transparency: I generated the initial patch with driver-os, a coding-agent harness I'm building. I wrote the failing test scenarios by hand first and confirmed them red, and the final change was reviewed and hardened by hand (the del and existing-null cases came out of that review).
