### PR TITLE
Guard ExpressionParser initialization with sync.Once

### DIFF
--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -15,7 +15,7 @@ var ExpressionParser ExpressionParserInterface
 
 var expressionParserOnce sync.Once
 
-// InitExpressionParser initializes the package level ExpressionParser, and is
+// InitExpressionParser initialises the package level ExpressionParser, and is
 // safe to call concurrently. The evaluators call it on every Evaluate, so
 // without the guard two goroutines could construct a parser at the same time,
 // and newParticipleLexer populates the shared participleYqRules entries as it

--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -8,14 +8,24 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 var ExpressionParser ExpressionParserInterface
 
+var expressionParserOnce sync.Once
+
+// InitExpressionParser initializes the package level ExpressionParser, and is
+// safe to call concurrently. The evaluators call it on every Evaluate, so
+// without the guard two goroutines could construct a parser at the same time,
+// and newParticipleLexer populates the shared participleYqRules entries as it
+// goes, which a third goroutine could be reading through getYqDefinition.
 func InitExpressionParser() {
-	if ExpressionParser == nil {
-		ExpressionParser = newExpressionParser()
-	}
+	expressionParserOnce.Do(func() {
+		if ExpressionParser == nil {
+			ExpressionParser = newExpressionParser()
+		}
+	})
 }
 
 var log = newLogger()

--- a/pkg/yqlib/lib_test.go
+++ b/pkg/yqlib/lib_test.go
@@ -3,6 +3,7 @@ package yqlib
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mikefarah/yq/v4/test"
@@ -543,5 +544,41 @@ func TestProcessEscapeCharacters(t *testing.T) {
 	for _, tt := range processEscapeCharactersScenarios {
 		actual := processEscapeCharacters(tt.input)
 		test.AssertResultComplexWithContext(t, tt.expected, actual, fmt.Sprintf("Input: %q", tt.input))
+	}
+}
+
+// TestInitExpressionParserConcurrent covers the data race described in #2788.
+// The evaluators call InitExpressionParser on every Evaluate, so before it was
+// guarded two goroutines could build a parser at the same time while a third
+// read the shared participleYqRules entries that newParticipleLexer fills in.
+//
+// To reproduce the original race the process must not have initialized the
+// parser yet, so run this test on its own with the detector enabled:
+//
+//	go test -race -run TestInitExpressionParserConcurrent ./pkg/yqlib/
+func TestInitExpressionParserConcurrent(t *testing.T) {
+	const goroutines = 32
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			InitExpressionParser()
+			if _, err := ExpressionParser.ParseExpression(".a.b"); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent ParseExpression failed: %v", err)
+	}
+	if ExpressionParser == nil {
+		t.Fatal("ExpressionParser should be initialized after concurrent InitExpressionParser calls")
 	}
 }

--- a/pkg/yqlib/lib_test.go
+++ b/pkg/yqlib/lib_test.go
@@ -552,7 +552,7 @@ func TestProcessEscapeCharacters(t *testing.T) {
 // guarded two goroutines could build a parser at the same time while a third
 // read the shared participleYqRules entries that newParticipleLexer fills in.
 //
-// To reproduce the original race the process must not have initialized the
+// To reproduce the original race the process must not have initialised the
 // parser yet, so run this test on its own with the detector enabled:
 //
 //	go test -race -run TestInitExpressionParserConcurrent ./pkg/yqlib/
@@ -579,6 +579,6 @@ func TestInitExpressionParserConcurrent(t *testing.T) {
 		t.Fatalf("concurrent ParseExpression failed: %v", err)
 	}
 	if ExpressionParser == nil {
-		t.Fatal("ExpressionParser should be initialized after concurrent InitExpressionParser calls")
+		t.Fatal("ExpressionParser should be initialised after concurrent InitExpressionParser calls")
 	}
 }


### PR DESCRIPTION
`yqlib` cannot currently be used from more than one goroutine, and the fix is small: the evaluators call `InitExpressionParser` on every `Evaluate`, so concurrent callers build a parser at the same time. This wraps that initialization in a `sync.Once`. The CLI is unaffected either way, since `cmd/root.go` already initializes once at startup.

Details and a standalone reproducer are in #2788.

### What races

Two package level things get written on each call:

- `ExpressionParser` itself, guarded only by a nil check.
- The `ParticipleTokenType` field on each shared `participleYqRules` entry, which `newParticipleLexer` fills in while building the lexer. Another goroutine can be reading those through `getYqDefinition`.

Both are pointer and struct field writes rather than map writes, so the runtime does not stop the process. It corrupts quietly, which is probably why this has gone unnoticed.

### The change

`InitExpressionParser` now does its work inside a `sync.Once`. The nil check stays inside it, so a caller that assigns `ExpressionParser` itself is still respected. Nothing else in the tree assigns that variable, and no test resets it, so behaviour is otherwise unchanged.

### Test

`TestInitExpressionParserConcurrent` in `pkg/yqlib/lib_test.go`.

One honest caveat about it. Reproducing the original race needs a process where nothing has initialized the parser yet, and in a full package run `expression_parser_test.go` sorts before `lib_test.go` and initializes it first. So the reproducing command is the test on its own, which is in a comment above it:

```
go test -race -run TestInitExpressionParserConcurrent ./pkg/yqlib/
```

On master that reports data races in `newParticipleLexer` and `getYqDefinition`. With this change it passes. In a full run the test still exercises concurrent initialization, it just cannot be the one that triggers the first init.

I noticed `scripts/test.sh` does not pass `-race`, so this test will not catch a regression in CI as things stand. Happy to add a `-race` run if you would like one, but that felt like your call rather than something to slip into a bug fix.

`go build ./...`, `go vet ./pkg/yqlib/` and `gofmt` are clean. `go test ./pkg/yqlib/` has one failure, `TestTomlScenarios`, which fails identically on master here, so I have left it alone.
