### PR TITLE
fix(hcl): quote string values in HCL output

### DIFF
--- a/pkg/yqlib/candidate_node.go
+++ b/pkg/yqlib/candidate_node.go
@@ -27,8 +27,8 @@ const (
 	FlowStyle
 )
 
-// EncodeHint controls how a mapping node is serialised by format-specific encoders
-// that distinguish between inline and block/section representations (e.g. TOML, HCL).
+// EncodeHint controls how a node is serialised by format-specific encoders, e.g.
+// distinguishing between inline and block/section representations (TOML, HCL).
 type EncodeHint int
 
 const (
@@ -41,6 +41,11 @@ const (
 	// EncodeHintInline forces the node to be emitted as an inline / flow table
 	// (used by TOML inline-table decoder and TOML encoder).
 	EncodeHintInline
+	// EncodeHintRawExpression marks a scalar string node as a raw HCL expression
+	// (an identifier traversal, function call, or arithmetic expression) that must
+	// be emitted without quotes. Only the HCL decoder sets this, for nodes that were
+	// unquoted in the source; ordinary strings are always quoted on encode.
+	EncodeHintRawExpression
 )
 
 func createStringScalarNode(stringValue string) *CandidateNode {

--- a/pkg/yqlib/decoder_hcl.go
+++ b/pkg/yqlib/decoder_hcl.go
@@ -381,15 +381,21 @@ func convertHclExprToNode(expr hclsyntax.Expression, src []byte) *CandidateNode 
 		end := r.End.Byte
 		if start >= 0 && end >= start && end <= len(src) {
 			text := strings.TrimSpace(string(src[start:end]))
-			return createStringScalarNode(text)
+			node := createStringScalarNode(text)
+			node.EncodeHint = EncodeHintRawExpression
+			return node
 		}
 		// Fallback to root name if source unavailable
 		if len(e.Traversal) > 0 {
 			if root, ok := e.Traversal[0].(hcl.TraverseRoot); ok {
-				return createStringScalarNode(root.Name)
+				node := createStringScalarNode(root.Name)
+				node.EncodeHint = EncodeHintRawExpression
+				return node
 			}
 		}
-		return createStringScalarNode("")
+		node := createStringScalarNode("")
+		node.EncodeHint = EncodeHintRawExpression
+		return node
 	case *hclsyntax.FunctionCallExpr:
 		// Preserve function calls as raw expressions for roundtrip
 		r := e.Range()
@@ -398,11 +404,11 @@ func convertHclExprToNode(expr hclsyntax.Expression, src []byte) *CandidateNode 
 		if start >= 0 && end >= start && end <= len(src) {
 			text := strings.TrimSpace(string(src[start:end]))
 			node := createStringScalarNode(text)
-			node.Style = 0
+			node.EncodeHint = EncodeHintRawExpression
 			return node
 		}
 		node := createStringScalarNode(e.Name)
-		node.Style = 0
+		node.EncodeHint = EncodeHintRawExpression
 		return node
 	default:
 		// try to evaluate the expression (handles unary, binary ops, etc.)
@@ -419,7 +425,7 @@ func convertHclExprToNode(expr hclsyntax.Expression, src []byte) *CandidateNode 
 			text := string(src[start:end])
 			// Mark as unquoted expression so encoder emits without quoting
 			node := createStringScalarNode(text)
-			node.Style = 0
+			node.EncodeHint = EncodeHintRawExpression
 			return node
 		}
 		return createStringScalarNode(fmt.Sprintf("%v", expr))

--- a/pkg/yqlib/encoder_hcl.go
+++ b/pkg/yqlib/encoder_hcl.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hclwrite "github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
@@ -283,26 +282,6 @@ func isHCLIdentifierPart(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
 }
 
-func isValidHCLIdentifier(s string) bool {
-	if s == "" {
-		return false
-	}
-	// HCL identifiers must start with a letter or underscore
-	// and contain only letters, digits, underscores, and hyphens
-	for i, r := range s {
-		if i == 0 {
-			if !isHCLIdentifierStart(r) {
-				return false
-			}
-			continue
-		}
-		if !isHCLIdentifierPart(r) {
-			return false
-		}
-	}
-	return true
-}
-
 // tokensForRawHCLExpr produces a minimal token stream for a simple HCL expression so we can
 // write it without introducing quotes (e.g. function calls like upper(message)).
 func tokensForRawHCLExpr(expr string) (hclwrite.Tokens, error) {
@@ -356,16 +335,11 @@ func tokensForRawHCLExpr(expr string) (hclwrite.Tokens, error) {
 // encodeAttribute encodes a value as an HCL attribute
 func (he *hclEncoder) encodeAttribute(body *hclwrite.Body, key string, valueNode *CandidateNode) error {
 	if valueNode.Kind == ScalarNode && valueNode.Tag == "!!str" {
-		// Handle unquoted expressions (as-is, without quotes)
-		if valueNode.Style == 0 {
-			tokens, err := tokensForRawHCLExpr(valueNode.Value)
-			if err != nil {
-				return err
-			}
-			body.SetAttributeRaw(key, tokens)
-			return nil
-		}
-		if valueNode.Style&LiteralStyle != 0 {
+		// Handle raw HCL expressions (identifier traversals, function calls, arithmetic)
+		// preserved verbatim from a round-tripped HCL source, without quotes. Ordinary
+		// strings (including those with no explicit style, e.g. yq-constructed values)
+		// are quoted below via cty.Value, since HCL requires all plain strings to be quoted.
+		if valueNode.EncodeHint == EncodeHintRawExpression {
 			tokens, err := tokensForRawHCLExpr(valueNode.Value)
 			if err != nil {
 				return err
@@ -376,14 +350,6 @@ func (he *hclEncoder) encodeAttribute(body *hclwrite.Body, key string, valueNode
 		// Check if template with interpolation
 		if valueNode.Style&DoubleQuotedStyle != 0 && strings.Contains(valueNode.Value, "${") {
 			return he.encodeTemplateAttribute(body, key, valueNode.Value)
-		}
-		// Check if unquoted identifier
-		if isValidHCLIdentifier(valueNode.Value) && valueNode.Style == 0 {
-			traversal := hcl.Traversal{
-				hcl.TraverseRoot{Name: valueNode.Value},
-			}
-			body.SetAttributeTraversal(key, traversal)
-			return nil
 		}
 	}
 	// Default: use cty.Value for quoted strings and all other types

--- a/pkg/yqlib/hcl_test.go
+++ b/pkg/yqlib/hcl_test.go
@@ -472,6 +472,29 @@ var hclFormatScenarios = []formatScenario{
 		expected:     "service {\n  optional_field = null\n}\n",
 		scenarioType: "roundtrip",
 	},
+	{
+		description:  "Regression: string set via expression is quoted (#2594)",
+		skipDoc:      true,
+		input:        ``,
+		expression:   `.zone = "us-east1-b"`,
+		expected:     "zone = \"us-east1-b\"\n",
+		scenarioType: "roundtrip",
+	},
+	{
+		description:  "Regression: identifier-shaped string set via expression is still quoted (#2594)",
+		skipDoc:      true,
+		input:        ``,
+		expression:   `.name = "web_proxy"`,
+		expected:     "name = \"web_proxy\"\n",
+		scenarioType: "roundtrip",
+	},
+	{
+		description:  "Roundtrip: preserves unquoted variable reference",
+		skipDoc:      true,
+		input:        `attr = var.foo`,
+		expected:     "attr = var.foo\n",
+		scenarioType: "roundtrip",
+	},
 }
 
 func testHclScenario(t *testing.T, s formatScenario) {


### PR DESCRIPTION
## Summary

`-ohcl` doesn't quote string values:

```sh
$ yq -n -ohcl '.zone = "us-east1-b"'
zone = us-east1-b
```

This produces invalid/non-round-trippable HCL (`zone = us-east1-b` is a reference to an undefined identifier, not the string `"us-east1-b"`).

## Root cause

`hclEncoder.encodeAttribute` used `valueNode.Style == 0` as the signal for "this is a raw, unquoted HCL expression that should be preserved verbatim" (e.g. an identifier traversal like `var.foo`, or a function call like `upper(message)`, round-tripped from HCL source). But `Style == 0` is also just the default zero-value for *any* ordinary string node that wasn't explicitly given another style, including:

- strings set via a yq expression against non-HCL input, e.g. `-n -ohcl '.zone = "us-east1-b"'`
- strings decoded from JSON/YAML and re-encoded to HCL, since those formats have no notion of "unquoted expression" (see the `kms.tf` round-trip example in the comments on #2594)

So plain string literals were systematically misidentified as raw expressions and emitted unquoted.

There was also a second, independent branch (`valueNode.Style&LiteralStyle != 0`) with the same problem, and a third branch (`isValidHCLIdentifier(...) && valueNode.Style == 0`) that was actually dead code (unreachable, since the `Style == 0` branch above it always returns first) — but would have become live and reintroduced this exact bug for identifier-shaped strings (like `us-east1-b`) once the first branch was fixed, so I removed it too.

## Fix

Introduced `EncodeHintRawExpression`, an explicit hint (reusing the existing generic `EncodeHint` mechanism already used elsewhere in this file for HCL block-encoding decisions) set **only** by the HCL decoder on the specific expression kinds that must stay unquoted to round-trip correctly: `ScopeTraversalExpr` (identifier/variable references), `FunctionCallExpr`, and the fallback case for expressions it can't parse but can still evaluate/preserve as source text.

The encoder now only takes the "raw, unquoted" path when this hint is explicitly set. Every other string goes through the existing `cty.Value` path, which always quotes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/yqlib/...` — all existing HCL tests pass unchanged
- [x] Added 3 regression cases to `hclFormatScenarios` in `hcl_test.go`:
  - a plain string set via expression is quoted (direct repro of #2594)
  - an identifier-shaped string (e.g. `web_proxy`) set via expression is still quoted (covers the now-removed dead-code branch)
  - `var.foo`-style variable references still round-trip unquoted through pure HCL→HCL (no regression to the intended raw-expression behavior)
- [x] Manually verified the exact repros from the issue and its follow-up comment:
  ```sh
  $ yq -n -ohcl '.zone = "us-east1-b"'
  zone = "us-east1-b"
  ```
  and the `kms.tf` round-trip via `-ojson`/`-pjson` now quotes `description`, `source`, and `version` correctly (this necessarily also quotes `some_attr = var.foo` once it round-trips through JSON, since JSON has no way to represent "this is a raw expression, not a string" — as noted in the issue thread, this is an inherent limitation of that intermediate format, not something this fix can preserve; direct HCL→HCL round-trips of `var.foo` are unaffected)
- [x] Note: I ran the full `go test ./...` suite and found 15 pre-existing failures on my Windows dev machine (symlink test, and several `cmd` package tests hardcoding `/bin/echo` etc.) — these reproduce identically on unmodified `master` and are unrelated to this change (confirmed via `git stash`).

Fixes #2594