### PR TITLE
fix: data race in InitExpressionParser

### DIFF
--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -8,14 +8,21 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 var ExpressionParser ExpressionParserInterface
 
+var initExpressionParserOnce sync.Once
+
+// InitExpressionParser initialises the package-level ExpressionParser, if it
+// hasn't been already. Safe to call from multiple goroutines concurrently:
+// the parser is built at most once, and every caller observes the same
+// fully-initialised instance.
 func InitExpressionParser() {
-	if ExpressionParser == nil {
+	initExpressionParserOnce.Do(func() {
 		ExpressionParser = newExpressionParser()
-	}
+	})
 }
 
 var log = newLogger()

--- a/pkg/yqlib/lib_test.go
+++ b/pkg/yqlib/lib_test.go
@@ -3,6 +3,7 @@ package yqlib
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mikefarah/yq/v4/test"
@@ -13,6 +14,27 @@ func TestGetLogger(t *testing.T) {
 	if l != log {
 		t.Fatal("GetLogger should return the yq logger instance, not a copy")
 	}
+}
+
+// Regression test for https://github.com/mikefarah/yq/issues/2788: calling
+// InitExpressionParser (directly, or indirectly via a StringEvaluator) from
+// multiple goroutines concurrently used to race on the package-level
+// ExpressionParser variable and on shared lexer rule state mutated while
+// building it. Run with -race to check.
+func TestInitExpressionParser_ConcurrentEvaluate(t *testing.T) {
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			encoder := NewYamlEncoder(ConfiguredYamlPreferences)
+			decoder := NewYamlDecoder(ConfiguredYamlPreferences)
+			if _, err := NewStringEvaluator().Evaluate(".a.b", "a:\n  b: value\n", encoder, decoder); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 type parseSnippetScenario struct {


### PR DESCRIPTION
## What's the bug

`yqlib` cannot currently be used from more than one goroutine: `go test -race` reports a data race on every run of a small program that calls `NewStringEvaluator().Evaluate` concurrently. The `yq` CLI itself is unaffected, because `cmd/root.go` calls `InitExpressionParser()` once at startup, before any evaluation - only library consumers hit this.

## Root cause

`InitExpressionParser` (`pkg/yqlib/lib.go`) used an unsynchronized nil-check "lazy init" pattern:

```go
func InitExpressionParser() {
	if ExpressionParser == nil {
		ExpressionParser = newExpressionParser()
	}
}
```

Two goroutines calling it concurrently can both observe `ExpressionParser` as `nil` and both call `newExpressionParser()`, racing on the write to the package-level `ExpressionParser` variable.

`newExpressionParser()` also calls `newParticipleLexer()`, which mutates the shared package-level `participleYqRules` slice's elements in place:

```go
for _, yqRule := range participleYqRules {
	yqRule.ParticipleTokenType = symbols[yqRule.Name]
}
```

so a third goroutine reading those same fields via `getYqDefinition` can race too. These are plain pointer/struct field accesses rather than map accesses, so the race corrupts state quietly instead of the process aborting the way it would for a racy map - easy to miss without `-race`.

## The fix

Wrap the assignment in a `sync.Once` so it happens exactly once, with a proper happens-before edge for every later reader:

```go
var initExpressionParserOnce sync.Once

func InitExpressionParser() {
	initExpressionParserOnce.Do(func() {
		ExpressionParser = newExpressionParser()
	})
}
```

`ExpressionParser` stays a public package-level variable for backward compatibility, since it's read directly by several callers (`operator_eval.go`, `operator_expression.go`, `operator_strings.go`, `stream_evaluator.go`, `cmd/utils.go`), not just through `InitExpressionParser()`.

## Testing

- Added `TestInitExpressionParser_ConcurrentEvaluate` (`pkg/yqlib/lib_test.go`), which spawns 32 goroutines each calling `NewStringEvaluator().Evaluate` concurrently - matching the reporter's own reproducer almost exactly.
- Verified with `go test -race`: **without** the fix this reliably reports both races described above (confirmed by temporarily reverting just the `lib.go` change and rerunning); **with** the fix it passes cleanly across repeated runs (`-count=5`, and again in isolation).
- Ran the full `go test -race ./pkg/yqlib/... ./cmd/...` suite. The only two failures (`TestLoadScenarios`, `TestTomlScenarios`) are unrelated to this change and pre-existing - confirmed by reproducing them identically on an unmodified checkout: one is a `\r\n` vs `\n` line-ending difference from my Windows checkout, and the other is a wording difference in the vendored TOML parser's error message (`"basic string not terminated by \""` vs `"unterminated basic string"`), from dependency drift, not from anything this PR touches. (I don't have a Go toolchain on this machine, so everything was built/tested via Docker.)

Fixes #2788
