### PR TITLE
Fix input file descriptor leak across multi-file evaluation

### DIFF
--- a/acceptance_tests/file-descriptors.sh
+++ b/acceptance_tests/file-descriptors.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+setUp() {
+  rm test-fd-*.yml 2>/dev/null || true
+}
+
+tearDown() {
+  rm test-fd-*.yml 2>/dev/null || true
+}
+
+createInputFiles() {
+  local index
+  for index in {1..80}; do
+    ln -s examples/sample.yaml "test-fd-${index}.yml"
+  done
+}
+
+testEvalClosesInputFiles() {
+  createInputFiles
+
+  (ulimit -n 32; GOGC=off ./yq eval 'select(false)' test-fd-*.yml)
+  assertEquals 0 "$?"
+}
+
+testEvalAllClosesInputFiles() {
+  createInputFiles
+
+  (ulimit -n 32; GOGC=off ./yq eval-all 'select(false)' test-fd-*.yml)
+  assertEquals 0 "$?"
+}
+
+source ./scripts/shunit2

--- a/pkg/yqlib/all_at_once_evaluator.go
+++ b/pkg/yqlib/all_at_once_evaluator.go
@@ -49,12 +49,7 @@ func (e *allAtOnceEvaluator) EvaluateFiles(expression string, filenames []string
 
 	var allDocuments = list.New()
 	for _, filename := range filenames {
-		reader, err := readStream(filename)
-		if err != nil {
-			return err
-		}
-
-		fileDocuments, err := readDocuments(reader, filename, fileIndex, decoder)
+		fileDocuments, err := readDocumentsFromFile(filename, fileIndex, decoder)
 		if err != nil {
 			return err
 		}
@@ -72,4 +67,14 @@ func (e *allAtOnceEvaluator) EvaluateFiles(expression string, filenames []string
 		return err
 	}
 	return printer.PrintResults(matches)
+}
+
+func readDocumentsFromFile(filename string, fileIndex int, decoder Decoder) (*list.List, error) {
+	reader, err := readStream(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer SafelyCloseReader(reader)
+
+	return readDocuments(reader, filename, fileIndex, decoder)
 }

--- a/pkg/yqlib/all_at_once_evaluator_test.go
+++ b/pkg/yqlib/all_at_once_evaluator_test.go
@@ -2,6 +2,7 @@ package yqlib
 
 import (
 	"bufio"
+	"os"
 	"strings"
 	"testing"
 
@@ -75,4 +76,24 @@ func TestTomlDecoderCanBeReinitializedAcrossDocuments(t *testing.T) {
 		t.Fatalf("expected second document count to be 1, got %d", secondDocuments.Len())
 	}
 	test.AssertResult(t, "Banana", secondDocuments.Front().Value.(*CandidateNode).Content[1].Value)
+}
+
+func TestReadDocumentsLeavesReaderOpen(t *testing.T) {
+	filename := t.TempDir() + "/input.yml"
+	if err := os.WriteFile(filename, []byte("a: apple\n"), 0600); err != nil {
+		t.Fatalf("failed to write input file: %v", err)
+	}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		t.Fatalf("failed to open input file: %v", err)
+	}
+	defer file.Close()
+
+	if _, err := ReadDocuments(file, NewYamlDecoder(ConfiguredYamlPreferences)); err != nil {
+		t.Fatalf("failed to read documents: %v", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		t.Fatalf("ReadDocuments closed the caller-owned reader: %v", err)
+	}
 }

--- a/pkg/yqlib/file_utils.go
+++ b/pkg/yqlib/file_utils.go
@@ -62,6 +62,10 @@ func SafelyCloseReader(reader io.Reader) {
 	switch reader := reader.(type) {
 	case *os.File:
 		safelyCloseFile(reader)
+	case io.Closer:
+		if err := reader.Close(); err != nil {
+			log.Errorf("Error closing reader: %v", err)
+		}
 	}
 }
 

--- a/pkg/yqlib/front_matter_test.go
+++ b/pkg/yqlib/front_matter_test.go
@@ -142,6 +142,7 @@ Some content
 	}
 	decoder := NewYamlDecoder(ConfiguredYamlPreferences)
 	docs, err := readDocuments(reader, tempFilename, 0, decoder)
+	SafelyCloseReader(reader)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/yqlib/stream_evaluator.go
+++ b/pkg/yqlib/stream_evaluator.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 )
 
 // A yaml expression evaluator that runs the expression multiple times for each given yaml document.
@@ -50,21 +49,11 @@ func (s *streamEvaluator) EvaluateFiles(expression string, filenames []string, p
 	}
 
 	for _, filename := range filenames {
-		reader, err := readStream(filename)
-
-		if err != nil {
-			return err
-		}
-		processedDocs, err := s.Evaluate(filename, reader, node, printer, decoder)
+		processedDocs, err := s.evaluateFile(filename, node, printer, decoder)
 		if err != nil {
 			return err
 		}
 		totalProcessDocs = totalProcessDocs + processedDocs
-
-		switch reader := reader.(type) {
-		case *os.File:
-			safelyCloseFile(reader)
-		}
 	}
 
 	if totalProcessDocs == 0 {
@@ -73,6 +62,16 @@ func (s *streamEvaluator) EvaluateFiles(expression string, filenames []string, p
 	}
 
 	return nil
+}
+
+func (s *streamEvaluator) evaluateFile(filename string, node *ExpressionNode, printer Printer, decoder Decoder) (uint, error) {
+	reader, err := readStream(filename)
+	if err != nil {
+		return 0, err
+	}
+	defer SafelyCloseReader(reader)
+
+	return s.Evaluate(filename, reader, node, printer, decoder)
 }
 
 func (s *streamEvaluator) Evaluate(filename string, reader io.Reader, node *ExpressionNode, printer Printer, decoder Decoder) (uint, error) {

--- a/pkg/yqlib/utils.go
+++ b/pkg/yqlib/utils.go
@@ -32,21 +32,23 @@ func resolveFilename(filename string) string {
 	return filename
 }
 
-func readStream(filename string) (io.Reader, error) {
-	var reader *bufio.Reader
-	if filename == "-" {
-		reader = bufio.NewReader(os.Stdin)
-	} else {
-		// ignore CWE-22 gosec issue - that's more targeted for http based apps that run in a public directory,
-		// and ensuring that it's not possible to give a path to a file outside that directory.
-		file, err := os.Open(filename) // #nosec
-		if err != nil {
-			return nil, err
-		}
-		reader = bufio.NewReader(file)
-	}
-	return reader, nil
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
 
+func readStream(filename string) (io.ReadCloser, error) {
+	if filename == "-" {
+		return io.NopCloser(bufio.NewReader(os.Stdin)), nil
+	}
+
+	// ignore CWE-22 gosec issue - that's more targeted for http based apps that run in a public directory,
+	// and ensuring that it's not possible to give a path to a file outside that directory.
+	file, err := os.Open(filename) // #nosec
+	if err != nil {
+		return nil, err
+	}
+	return &readCloser{Reader: bufio.NewReader(file), Closer: file}, nil
 }
 
 func writeString(writer io.Writer, txt string) error {
@@ -71,10 +73,6 @@ func readDocuments(reader io.Reader, filename string, fileIndex int, decoder Dec
 		candidateNode, errorReading := decoder.Decode()
 
 		if errors.Is(errorReading, io.EOF) {
-			switch reader := reader.(type) {
-			case *os.File:
-				safelyCloseFile(reader)
-			}
 			return inputList, nil
 		} else if errorReading != nil {
 			return nil, fmt.Errorf("bad file '%v': %w", filename, errorReading)


### PR DESCRIPTION
## Summary

- return an owned `io.ReadCloser` from `readStream`
- close each input within a per-file scope in both streaming and all-at-once evaluators
- keep readers passed to `ReadDocuments` caller-owned
- add low file-descriptor acceptance coverage for `eval` and `eval-all`

## Root cause

`readStream` wrapped each opened `*os.File` in a `*bufio.Reader`. The evaluator cleanup type-switch therefore could not reach the underlying file, so descriptors accumulated until garbage collection or process exit.

The new per-file helpers defer closing the owned reader, covering both successful evaluation and error returns without retaining descriptors for the full multi-file run.

## User impact

Multi-file commands now work under low file-descriptor limits instead of failing partway through with `too many open files`.

Fixes #2796.

## Validation

- `bash acceptance_tests/file-descriptors.sh`
- original `prlimit --nofile=32:32` reproduction for both `eval` and `eval-all`
- full `bash scripts/acceptance.sh`
- full Go tests with only the independently reproduced baseline `TestTomlScenarios` failure skipped
- `go test -tags goinstall -run TestGoInstallCompatibility .`
- `make test`: formatting, spelling, gosec, and golangci-lint passed; the Go test phase hit the same TOML error-message mismatch reproduced on clean `origin/master`
