### PR TITLE
perf: use io.WriteString in writeString to avoid a heap allocation

### DIFF
--- a/pkg/yqlib/utils.go
+++ b/pkg/yqlib/utils.go
@@ -50,7 +50,7 @@ func readStream(filename string) (io.Reader, error) {
 }
 
 func writeString(writer io.Writer, txt string) error {
-	_, errorWriting := writer.Write([]byte(txt))
+	_, errorWriting := io.WriteString(writer, txt)
 	return errorWriting
 }
 

--- a/pkg/yqlib/utils_test.go
+++ b/pkg/yqlib/utils_test.go
@@ -1,0 +1,41 @@
+package yqlib
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/mikefarah/yq/v4/test"
+)
+
+// plainWriter only implements io.Writer, so io.WriteString must fall back to Write.
+type plainWriter struct {
+	buf bytes.Buffer
+}
+
+func (w *plainWriter) Write(p []byte) (int, error) {
+	return w.buf.Write(p)
+}
+
+func TestWriteStringToStringWriter(t *testing.T) {
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+	test.AssertResult(t, nil, writeString(writer, "hello world"))
+	test.AssertResult(t, nil, writer.Flush())
+	test.AssertResult(t, "hello world", buf.String())
+}
+
+func TestWriteStringToPlainWriter(t *testing.T) {
+	writer := &plainWriter{}
+	test.AssertResult(t, nil, writeString(writer, "hello world"))
+	test.AssertResult(t, "hello world", writer.buf.String())
+}
+
+func TestWriteStringDoesNotAllocate(t *testing.T) {
+	writer := bufio.NewWriter(io.Discard)
+	allocations := testing.AllocsPerRun(100, func() {
+		_ = writeString(writer, "hello world")
+	})
+	test.AssertResult(t, 0.0, allocations)
+}


### PR DESCRIPTION
> **AI agent disclosure:** This pull request was written by an AI agent (Claude Code) acting on the user's behalf, not by the user personally. Every command and result quoted below was actually executed; the claims were verified against real output before submitting.

Fixes #2807.

## What

`writeString` in `pkg/yqlib/utils.go` converted every string to `[]byte` before calling `io.Writer.Write`. Go's escape analysis reports that conversion as escaping to the heap, so every call through this shared helper allocated a copy of the string.

This switches the helper to `io.WriteString(writer, txt)`. For writers implementing `io.StringWriter` — including the `*bufio.Writer` the standard printer path uses — this writes the string directly with no copy. Any other `io.Writer` keeps the standard library's `Write([]byte(s))` fallback, so behaviour is unchanged. The signature and all call sites are untouched. `encoder_shellvariables.go` already uses `io.WriteString`, so this aligns the shared helper with existing practice.

```diff
 func writeString(writer io.Writer, txt string) error {
-	_, errorWriting := writer.Write([]byte(txt))
+	_, errorWriting := io.WriteString(writer, txt)
 	return errorWriting
 }
```

## Evidence

**Escape analysis — before** (`go build -gcflags=github.com/mikefarah/yq/v4/pkg/yqlib=-m=2 .`):

```
pkg/yqlib/utils.go:53:41: ([]byte)(txt) escapes to heap in writeString:
pkg/yqlib/utils.go:53:41:   flow: {heap} ← &{storage for ([]byte)(txt)}:
pkg/yqlib/utils.go:53:41:     from ([]byte)(txt) (spill) at pkg/yqlib/utils.go:53:41
pkg/yqlib/utils.go:53:41:     from writer.Write(([]byte)(txt)) (call parameter) at pkg/yqlib/utils.go:53:33
pkg/yqlib/utils.go:53:41: ([]byte)(txt) escapes to heap
```

**After** — no `escapes to heap` line for `writeString`; the remaining output is only parameter-leak notes for the interface call:

```
pkg/yqlib/utils.go:52:18: leaking param: writer
pkg/yqlib/utils.go:52:36: leaking param: txt
```

**Allocations** — micro-benchmark writing a 51-byte string to a `bufio.Writer` over `io.Discard` (arm64, Go toolchain from `go.mod`):

```
before:  133.5 ns/op   64 B/op   1 allocs/op
after:    26.4 ns/op    0 B/op   0 allocs/op
```

The end-to-end impact on a full yq invocation will be smaller and depends on how many scalars are written; the point of the change is removing a per-call allocation from a shared output path, not a headline speedup.

## Tests

Added `pkg/yqlib/utils_test.go` covering the helper directly, since it had no dedicated test before:

- `TestWriteStringToStringWriter` — the `io.StringWriter` path (`*bufio.Writer`) writes the expected bytes.
- `TestWriteStringToPlainWriter` — a writer implementing only `io.Writer` still works via the standard fallback, guarding the behaviour this change relies on.
- `TestWriteStringDoesNotAllocate` — `testing.AllocsPerRun` asserts 0 allocations, so a regression back to `[]byte(txt)` fails the suite.

## Verification run

```
$ gofmt -l .                      # (excluding vendor) no output
$ go vet ./...                    # no output
$ golangci-lint run pkg/yqlib/... # 0 issues.
$ go build ./...                  # ok
$ go test ./pkg/yqlib -run TestWriteString -v
--- PASS: TestWriteStringToStringWriter (0.00s)
--- PASS: TestWriteStringToPlainWriter (0.00s)
--- PASS: TestWriteStringDoesNotAllocate (0.00s)
$ typos pkg/yqlib/utils.go pkg/yqlib/utils_test.go   # clean
$ go test ./...
```

`go test ./...` has two failures on this branch — `TestTomlScenarios` (a TOML parser error-message wording difference) and `TestFormatStringFromFilename`. I confirmed both reproduce identically on unmodified `master` at 7862131, so they are pre-existing and unrelated to this change. `scripts/spelling.sh` could not run via the script wrapper because `typos` was not installed to `$HOME/go/bin` in this environment; I installed `typos` separately and ran it against the changed files, which is clean.

Happy to drop the test file or the benchmark-derived numbers if you'd prefer a more minimal diff.
