### PR TITLE
hcl: fix panic when decoding an object with a non-string key

### DIFF
--- a/pkg/yqlib/decoder_hcl.go
+++ b/pkg/yqlib/decoder_hcl.go
@@ -326,8 +326,9 @@ func convertHclExprToNode(expr hclsyntax.Expression, src []byte) *CandidateNode 
 		for _, item := range e.Items {
 			// evaluate key expression to get the key string
 			keyVal, keyDiags := item.KeyExpr.Value(nil)
-			if keyDiags != nil && keyDiags.HasErrors() {
+			if (keyDiags != nil && keyDiags.HasErrors()) || keyVal.Type() != cty.String {
 				// fallback: try to extract key from source
+				// (also covers non-string keys, e.g. numeric object keys, which AsString would panic on)
 				r := item.KeyExpr.Range()
 				start := r.Start.Byte
 				end := r.End.Byte

--- a/pkg/yqlib/hcl_test.go
+++ b/pkg/yqlib/hcl_test.go
@@ -177,6 +177,13 @@ var hclFormatScenarios = []formatScenario{
 		scenarioType: "decode",
 	},
 	{
+		description:  "object attribute with a non-string key",
+		skipDoc:      true,
+		input:        `intdict = { 1 = {} }`,
+		expected:     "intdict: {\"1\": {}}\n",
+		scenarioType: "decode",
+	},
+	{
 		description:  "nested block",
 		skipDoc:      true,
 		input:        `server { port = 8080 }`,


### PR DESCRIPTION
## What this PR does
Fixes #2795.

```
$ echo "intdict = { 1 = {} }" | yq eval --input-format=hcl .
panic: not a string
```

`convertHclExprToNode`'s `ObjectConsExpr` handling evaluates each key expression and calls `.AsString()` on the result. The existing fallback (extract the raw key text from source) only triggers when evaluation itself returns diagnostics errors. A bare numeric key like `1` evaluates without error but to a `cty.Number`, not a `cty.String`, so `.AsString()` panics.

## Fix
Extend the existing fallback condition to also cover keys that evaluate successfully but aren't strings, reusing the same source-extraction path already used for the error case.

## Verification
- Added a scenario in `hcl_test.go` decoding `intdict = { 1 = {} }`, asserting no panic and the expected YAML (`intdict: {"1": {}}`).
- Confirmed the new test reproduces the exact original panic (`AsString: not a string`) when the fix is reverted, and passes with the fix.
- `go build ./...`, `go vet ./pkg/yqlib/...`, `gofmt` clean.
- Full `pkg/yqlib` test suite run: no HCL-related failures. Two pre-existing, unrelated failures on this Windows dev environment (a TOML error-message wording difference on newer Go, and a symlink test needing elevated Windows privilege) — neither touches `decoder_hcl.go` or `hcl_test.go`.