### PR TITLE
fix: prevent panic when HCL object keys are non-strings

### DIFF
--- a/pkg/yqlib/decoder_hcl.go
+++ b/pkg/yqlib/decoder_hcl.go
@@ -252,6 +252,29 @@ func addBlockToMapping(parent *CandidateNode, block *hclsyntax.Block, src []byte
 	}
 }
 
+// ctyValueToKeyString converts a cty.Value to its string key representation
+// without panicking on non-string types.
+func ctyValueToKeyString(v cty.Value) string {
+	if v.Type().Equals(cty.String) {
+		return v.AsString()
+	}
+	switch {
+	case v.Type() == cty.Number:
+		bf := v.AsBigFloat()
+		if bf == nil {
+			return v.GoString()
+		}
+		if intVal, acc := bf.Int(nil); acc == big.Exact {
+			return intVal.String()
+		}
+		return bf.Text('g', -1)
+	case v.Type().Equals(cty.Bool):
+		return strconv.FormatBool(v.True())
+	default:
+		return v.GoString()
+	}
+}
+
 func convertHclExprToNode(expr hclsyntax.Expression, src []byte) *CandidateNode {
 	// handle literal values directly
 	switch e := expr.(type) {
@@ -338,7 +361,9 @@ func convertHclExprToNode(expr hclsyntax.Expression, src []byte) *CandidateNode 
 				}
 				continue
 			}
-			keyStr := keyVal.AsString()
+			// Convert key to string safely — non-string types (e.g. integers) must not
+			// call AsString() directly as that panics; use ctyValueToKeyString instead.
+			keyStr := ctyValueToKeyString(keyVal)
 			keyNode := createStringScalarNode(keyStr)
 			valNode := convertHclExprToNode(item.ValueExpr, src)
 			m.AddKeyValueChild(keyNode, valNode)


### PR DESCRIPTION
### Problem

`yq` panics with `panic: not a string` when parsing HCL input that contains object expressions with non-string keys, such as integer keys:

```hcl
intdict = { 1 = {} }
```

```
panic: not a string
goroutine 1 [running]:
github.com/zclconf/go-cty/cty.Value.AsString(...)
        cty/value_ops.go:1458 +0x124
github.com/mikefarah/yq/v4/pkg/yqlib.convertHclExprToNode(...)
        pkg/yqlib/decoder_hcl.go:341 +0x1594
```

### Root cause

In the `*hclsyntax.ObjectConsExpr` case of `convertHclExprToNode`, after evaluating the key expression with `item.KeyExpr.Value(nil)`, the code called `keyVal.AsString()` unconditionally. When the key is a `cty.Number` (or any non-string type), `AsString()` panics immediately.

### Fix

Add a helper `ctyValueToKeyString` that checks `v.Type().Equals(cty.String)` before calling `AsString()`, and for numeric/boolean/other key types falls back to a string representation. Replace the bare `keyVal.AsString()` call in `ObjectConsExpr` handling with this helper.

Numeric keys (like `1`) are converted to `"1"`, matching the behaviour of OpenTofu/Terragrunt when they encounter such constructs.

Fixes #2795