### PR TITLE
docs: fix typo in string operators documentation

### DIFF
--- a/pkg/yqlib/doc/operators/headers/string-operators.md
+++ b/pkg/yqlib/doc/operators/headers/string-operators.md
@@ -27,7 +27,7 @@ a: |
   cat
 ```
 
-Using `$( exp )` wont work, as it will trim the trailing newline.
+Using `$( exp )` won't work, as it will trim the trailing newline.
 
 ```
 m=$(echo "cat\n") yq -n '.a = strenv(m)'

--- a/pkg/yqlib/doc/operators/string-operators.md
+++ b/pkg/yqlib/doc/operators/string-operators.md
@@ -27,7 +27,7 @@ a: |
   cat
 ```
 
-Using `$( exp )` wont work, as it will trim the trailing newline.
+Using `$( exp )` won't work, as it will trim the trailing newline.
 
 ```
 m=$(echo "cat\n") yq -n '.a = strenv(m)'


### PR DESCRIPTION
> This PR was prepared with the assistance of an AI agent acting on the contributor's behalf, not the contributor personally.

Fixes a typo in the string operators documentation: \wont\ -> \won't\. Updated both the generated operator doc and its header source.