### PR TITLE
fix(strings): allow quoted keys inside string interpolation (#2817)

### DIFF
--- a/pkg/yqlib/lexer_participle.go
+++ b/pkg/yqlib/lexer_participle.go
@@ -186,7 +186,7 @@ var participleYqRules = []*participleYqRule{
 
 	{"NullValue", `[Nn][Uu][Ll][Ll]|~`, nullValue(), 0},
 
-	{"QuotedStringValue", `"([^"\\]*(\\.[^"\\]*)*)"`, stringValue(), 0},
+	{"QuotedStringValue", `"((\\\([^)]*\)|\\.|[^"\\])*)"`, stringValue(), 0},
 
 	{"StrEnvOp", `strenv\([^\)]+\)`, envOp(true), 0},
 	{"EnvOp", `env\([^\)]+\)`, envOp(false), 0},

--- a/pkg/yqlib/operator_strings_test.go
+++ b/pkg/yqlib/operator_strings_test.go
@@ -40,6 +40,15 @@ var stringsOperatorScenarios = []expressionScenario{
 	},
 	{
 		skipDoc:     true,
+		description: "Interpolation - quoted key with special characters",
+		document:    "value: things\nFirst name: Bill",
+		expression:  `"Test: \( .["First name"])"`,
+		expected: []string{
+			"D0, P[], (!!str)::Test: Bill\n",
+		},
+	},
+	{
+		skipDoc:     true,
 		description: "Interpolation - don't",
 		document:    `value: things`,
 		expression:  `"Hi (.value)"`,


### PR DESCRIPTION
## What

Closes #2817.

String interpolation failed when the interpolated expression indexed a key containing special characters (e.g. a space):

```
$ yq '"Test: \( .["First name"])"' data.yaml
Error: 1:14: lexer: invalid input text "First name\"])\""
```

even though the same access works on its own (`yq '.["First name"]'` returns the value).

## Cause

The `QuotedStringValue` lexer rule in `pkg/yqlib/lexer_participle.go` was:

```
"([^"\\]*(\\.[^"\\]*)*)"
```

It matches a run of non-quote characters and `\`-escapes, so it stops at the **first** inner `"` — the opening quote of `"First name"` — and never sees the closing quote of the whole string. The interpolation block `\( ... )` is allowed to contain its own quoted strings, but the lexer didn't account for that.

## Fix

Extend the rule so a `\( ... )` interpolation block may contain quotes:

```
"((\\\([^)]*\)|\\.|[^"\\])*)"
```

i.e. an inner segment is either an interpolation block `\(...)`, an escape `\.`, or an ordinary non-quote/non-backslash character.

```
$ yq '"Test: \( .["First name"])"' data.yaml
Test: Bill
```

Simple interpolations, literal parentheses (`"Hi (.value)"`), escaped backslashes (`"Hi \\(.value)"`) and multiple interpolations are unchanged.

## Tests

Added an interpolation scenario in `pkg/yqlib/operator_strings_test.go` (`Interpolation - quoted key with special characters`).

**Verified RED→GREEN:** with the original regex, the new test fails with exactly `lexer: invalid input text "First name\"])"`; with the fix it passes.

## Validation (real results, Go)

- `go test ./pkg/yqlib/` — all pass except `TestTomlScenarios`, which fails identically on a clean `master` checkout (a TOML-library error-message wording difference, unrelated to this change).
- `go build ./...` and `gofmt -l` are clean.
