### PR TITLE
Don't clobber existing values when merging with null

### DIFF
--- a/pkg/yqlib/doc/operators/multiply-merge.md
+++ b/pkg/yqlib/doc/operators/multiply-merge.md
@@ -598,3 +598,22 @@ will output
 - some
 ```
 
+## Merge does not overwrite existing values with null
+A `null` value on the right hand side does not clobber the value on the left, matching the behaviour of merging with an explicit `null`. New keys are still added.
+
+Given a sample.yml file of:
+```yaml
+a: cat
+b: dog
+```
+then
+```bash
+yq '. * {"a": null, "c": null}' sample.yml
+```
+will output
+```yaml
+a: cat
+b: dog
+c: null
+```
+

--- a/pkg/yqlib/operator_multiply.go
+++ b/pkg/yqlib/operator_multiply.go
@@ -205,7 +205,16 @@ func applyAssignment(d *dataTreeNavigator, context Context, pathIndexToStartFrom
 	lhsPath := rhs.GetPath()[pathIndexToStartFrom:]
 	log.Debugf("merge - lhsPath %v", lhsPath)
 
-	assignmentOp := &Operation{OperationType: assignAttributesOpType, Preferences: preferences.AssignPrefs}
+	assignPrefs := preferences.AssignPrefs
+	if rhs.Tag == "!!null" {
+		// A null value on the RHS must not clobber an existing value on the
+		// LHS. This mirrors merging against a null (e.g. '{a: 1} * null'
+		// returns 'a: 1'). Restricting the write to null targets keeps that
+		// behaviour while still allowing brand new keys to be added as null.
+		assignPrefs.OnlyWriteNull = true
+	}
+
+	assignmentOp := &Operation{OperationType: assignAttributesOpType, Preferences: assignPrefs}
 	if shouldAppendArrays && rhs.Kind == SequenceNode {
 		assignmentOp.OperationType = addAssignOpType
 		log.Debugf("merge - assignmentOp.OperationType = addAssignOpType")

--- a/pkg/yqlib/operator_multiply_test.go
+++ b/pkg/yqlib/operator_multiply_test.go
@@ -687,6 +687,34 @@ var multiplyOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
+		description:    "Merge does not overwrite existing values with null",
+		subdescription: "A `null` value on the right hand side does not clobber the value on the left, matching the behaviour of merging with an explicit `null`. New keys are still added.",
+		document:       `{a: cat, b: dog}`,
+		expression:     `. * {"a": null, "c": null}`,
+		expected: []string{
+			"D0, P[], (!!map)::{a: cat, b: dog, c: null}\n",
+		},
+	},
+	{
+		// Regression test for https://github.com/mikefarah/yq/issues/2224
+		// A null value must not clobber an existing map or array.
+		skipDoc:    true,
+		document:   `{a: {b: bird}, c: [1]}`,
+		expression: `. * {"a": null, "c": null}`,
+		expected: []string{
+			"D0, P[], (!!map)::{a: {b: bird}, c: [1]}\n",
+		},
+	},
+	{
+		// Regression test for https://github.com/mikefarah/yq/issues/2224
+		// Appending arrays across a null value must not drop earlier entries.
+		skipDoc:    true,
+		expression: `{"list": [1]} *+ {"list": null} *+ {"list": [3]}`,
+		expected: []string{
+			"D0, P[], (!!map)::list:\n    - 1\n    - 3\n",
+		},
+	},
+	{
 		skipDoc:    true,
 		expression: `null * null`,
 		expected: []string{


### PR DESCRIPTION
**Describe the bug**

Merging a value against `null` overwrites the existing value instead of leaving it in place:

```bash
$ yq -n '{"a": 1} * {"a": null}'
a: null      # expected: a: 1
```

This is inconsistent with merging against a top-level `null`, which already keeps the left-hand side:

```bash
$ yq -n '{"a": 1} * null'
a: 1
```

It's especially surprising when reducing several documents together and one of them leaves a key empty (#2224):

`data1.yml` -> `list: [1]`, `data2.yml` -> `list:`, `data3.yml` -> `list: [3]`

```bash
$ yq ea '. as $item ireduce ({}; . *+ $item )' data1.yml data2.yml data3.yml
list:
  - 3          # the "1" from data1 has been dropped
```

**Fix**

When the right-hand side of a merge assignment is `null`, only write it when the target itself is `null`. Existing values are left untouched, while brand new keys are still added as `null`. This reuses the existing `OnlyWriteNull` assignment preference (the same mechanism behind the `n` merge flag), so the change is small and localised to `applyAssignment`.

After the fix:

```bash
$ yq -n '{"a": 1} * {"a": null}'
a: 1

$ yq ea '. as $item ireduce ({}; . *+ $item )' data1.yml data2.yml data3.yml
list:
  - 1
  - 3
```

Non-null values still overwrite as before, and merging brand new (null) keys still adds them.

**Tests / docs**

Added a documented scenario plus regression tests in `pkg/yqlib/operator_multiply_test.go`, and regenerated `pkg/yqlib/doc/operators/multiply-merge.md` via `go test -run TestMultiplyOperatorScenarios`.

Fixes #2224
