### PR TITLE
disable hard line wrapping

### DIFF
--- a/pkg/yqlib/encoder_yaml.go
+++ b/pkg/yqlib/encoder_yaml.go
@@ -2,6 +2,8 @@ package yqlib
 
 import (
 	"bytes"
+	"cmp"
+	"fmt"
 	"io"
 	"strings"
 
@@ -49,11 +51,14 @@ func (ye *yamlEncoder) Encode(writer io.Writer, node *CandidateNode) error {
 		destination = tempBuffer
 	}
 
-	var encoder = yaml.NewEncoder(destination)
-
-	encoder.SetIndent(ye.prefs.Indent)
-	if ye.prefs.CompactSequenceIndent {
-		encoder.CompactSeqIndent()
+	dumper, err := yaml.NewDumper(destination,
+		yaml.WithV3Defaults(),
+		yaml.WithIndent(cmp.Or(ye.prefs.Indent, 2)),
+		yaml.WithCompactSeqIndent(ye.prefs.CompactSequenceIndent),
+		yaml.WithLineWidth(-1),
+	)
+	if err != nil {
+		return fmt.Errorf("configure YAML encoding %#v: %v", ye.prefs, err)
 	}
 
 	target, err := node.MarshalYAML()
@@ -65,7 +70,7 @@ func (ye *yamlEncoder) Encode(writer io.Writer, node *CandidateNode) error {
 	trailingContent := target.FootComment
 	target.FootComment = ""
 
-	if err := encoder.Encode(target); err != nil {
+	if err := dumper.Dump(target); err != nil {
 		return err
 	}
 

--- a/pkg/yqlib/operator_load_test.go
+++ b/pkg/yqlib/operator_load_test.go
@@ -77,7 +77,7 @@ var loadScenarios = []expressionScenario{
 		document:       `{something: {file: "thing.yml"}, over: {here: [{file: "thing.yml"}]}}`,
 		expression:     `(.. | select(has("file"))) |= load("../../examples/" + .file)`,
 		expected: []string{
-			"D0, P[], (!!map)::{something: {a: apple is included, b: cool.}, over: {here: [{a: apple is included,\n                b: cool.}]}}\n",
+			"D0, P[], (!!map)::{something: {a: apple is included, b: cool.}, over: {here: [{a: apple is included, b: cool.}]}}\n",
 		},
 	},
 	{

--- a/pkg/yqlib/operator_multiply_test.go
+++ b/pkg/yqlib/operator_multiply_test.go
@@ -83,7 +83,7 @@ var nodeWithFooter = `a: apple
 
 var document = `a: &cat {name: cat}
 b: {name: dog}
-c: 
+c:
   <<: *cat
 `
 
@@ -514,7 +514,7 @@ var multiplyOperatorScenarios = []expressionScenario{
 		environmentVariables: map[string]string{"originalPath": ".myArray", "otherPath": ".newArray", "idPath": ".a"},
 		expression:           mergeExpression,
 		expected: []string{
-			"D0, P[], (!!map)::{myArray: [{a: apple, b: appleB2}, {a: kiwi, b: kiwiB}, {a: banana, b: bananaB, c: bananaC},\n        {a: dingo, c: dingoC}], something: else}\n",
+			"D0, P[], (!!map)::{myArray: [{a: apple, b: appleB2}, {a: kiwi, b: kiwiB}, {a: banana, b: bananaB, c: bananaC}, {a: dingo, c: dingoC}], something: else}\n",
 		},
 	},
 	{

--- a/pkg/yqlib/operator_select_test.go
+++ b/pkg/yqlib/operator_select_test.go
@@ -98,7 +98,7 @@ var selectOperatorScenarios = []expressionScenario{
 		document:    `[{animal: cat, legs: {cool: true}}, {animal: fish}]`,
 		expression:  `(.[] | select(.legs.cool == true).canWalk) = true | (.[] | .alive.things) = "yes"`,
 		expected: []string{
-			"D0, P[], (!!seq)::[{animal: cat, legs: {cool: true}, canWalk: true, alive: {things: yes}}, {animal: fish,\n        alive: {things: yes}}]\n",
+			"D0, P[], (!!seq)::[{animal: cat, legs: {cool: true}, canWalk: true, alive: {things: yes}}, {animal: fish, alive: {things: yes}}]\n",
 		},
 	},
 	{

--- a/pkg/yqlib/operator_sort_keys_test.go
+++ b/pkg/yqlib/operator_sort_keys_test.go
@@ -37,7 +37,7 @@ var sortKeysOperatorScenarios = []expressionScenario{
 		document:       `{bParent: {c: dog, array: [3,1,2]}, aParent: {z: donkey, x: [{c: yum, b: delish}, {b: ew, a: apple}]}}`,
 		expression:     `sort_keys(..)`,
 		expected: []string{
-			"D0, P[], (!!map)::{aParent: {x: [{b: delish, c: yum}, {a: apple, b: ew}], z: donkey}, bParent: {array: [\n            3, 1, 2], c: dog}}\n",
+			"D0, P[], (!!map)::{aParent: {x: [{b: delish, c: yum}, {a: apple, b: ew}], z: donkey}, bParent: {array: [3, 1, 2], c: dog}}\n",
 		},
 	},
 }

--- a/pkg/yqlib/yaml_test.go
+++ b/pkg/yqlib/yaml_test.go
@@ -106,6 +106,12 @@ var yamlFormatScenarios = []formatScenario{
 		input:       "[1, 2]",
 		expected:    "[1, 2]\n",
 	},
+	{
+		description: "long line",
+		skipDoc:     true,
+		input:       "field: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt",
+		expected:    "field: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt\n",
+	},
 }
 
 var yamlParseScenarios = []expressionScenario{


### PR DESCRIPTION
The formatting defaults of the used YAML library changed. Since yq has no mechanism for the user to override them, change them back to what we used before.

fixes https://github.com/mikefarah/yq/issues/2824, https://github.com/mikefarah/yq/issues/2823