### PR TITLE
fix: error on int64 overflow in +, -, * instead of silently wrapping

### DIFF
--- a/pkg/yqlib/lib.go
+++ b/pkg/yqlib/lib.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 	"sync"
@@ -202,6 +203,34 @@ func parseInt(numberString string) (int, error) {
 	}
 
 	return int(parsed), err
+}
+
+// checkedInt64Arithmetic performs '+', '-' or '*' on two int64 values and
+// returns the exact result only when it still fits in an int64. yq refuses to
+// silently wrap on int64 overflow (see issue #2820): a result outside
+// [math.MinInt64, math.MaxInt64] is reported as an error rather than returned
+// as a wrapped (and therefore wrong) value. big.Int is used so the exact
+// product/sum/difference is computed before the range check, which avoids the
+// sign-handling pitfalls of doing the overflow detection directly on the
+// wrapped int64 result.
+func checkedInt64Arithmetic(op byte, lhsNum, rhsNum int64) (int64, error) {
+	lhs := new(big.Int).SetInt64(lhsNum)
+	rhs := new(big.Int).SetInt64(rhsNum)
+	result := new(big.Int)
+	switch op {
+	case '+':
+		result.Add(lhs, rhs)
+	case '-':
+		result.Sub(lhs, rhs)
+	case '*':
+		result.Mul(lhs, rhs)
+	default:
+		return 0, fmt.Errorf("unknown arithmetic operator %q", op)
+	}
+	if !result.IsInt64() {
+		return 0, fmt.Errorf("%v %c %v overflows int64", lhsNum, op, rhsNum)
+	}
+	return result.Int64(), nil
 }
 
 func processEscapeCharacters(original string) string {

--- a/pkg/yqlib/operator_add.go
+++ b/pkg/yqlib/operator_add.go
@@ -122,7 +122,10 @@ func addScalars(context Context, target *CandidateNode, lhs *CandidateNode, rhs 
 		if err != nil {
 			return err
 		}
-		sum := lhsNum + rhsNum
+		sum, err := checkedInt64Arithmetic('+', lhsNum, rhsNum)
+		if err != nil {
+			return err
+		}
 		target.Tag = lhs.Tag
 		target.Value = fmt.Sprintf(format, sum)
 	} else if (lhsTag == "!!int" || lhsTag == "!!float") && (rhsTag == "!!int" || rhsTag == "!!float") {

--- a/pkg/yqlib/operator_add_test.go
+++ b/pkg/yqlib/operator_add_test.go
@@ -539,6 +539,15 @@ var addOperatorScenarios = []expressionScenario{
 			"D0, P[], (!!map)::? [{~: ~}]\n: v1\n? [{2: ~}]\n: v2\n",
 		},
 	},
+	{
+		// int64 + int64 that overflows int64. See issue #2820: previously
+		// this silently wrapped (MaxInt64 + 1 -> MinInt64).
+		description:   "Add integers that overflow int64",
+		skipDoc:       true,
+		document:      `a: 9223372036854775807`,
+		expression:    `.a + 1`,
+		expectedError: "9223372036854775807 + 1 overflows int64",
+	},
 }
 
 func TestAddOperatorScenarios(t *testing.T) {

--- a/pkg/yqlib/operator_multiply.go
+++ b/pkg/yqlib/operator_multiply.go
@@ -133,7 +133,11 @@ func multiplyIntegers(lhs *CandidateNode, rhs *CandidateNode) (*CandidateNode, e
 	if err != nil {
 		return nil, err
 	}
-	target.Value = fmt.Sprintf(format, lhsNum*rhsNum)
+	product, err := checkedInt64Arithmetic('*', lhsNum, rhsNum)
+	if err != nil {
+		return nil, err
+	}
+	target.Value = fmt.Sprintf(format, product)
 	return target, nil
 }
 

--- a/pkg/yqlib/operator_multiply_test.go
+++ b/pkg/yqlib/operator_multiply_test.go
@@ -716,6 +716,23 @@ var multiplyOperatorScenarios = []expressionScenario{
 		expression:    fmt.Sprintf(`"ab" * %d`, 1<<(bits.UintSize-2)),
 		expectedError: fmt.Sprintf("result of repeating string (2 bytes) by %d would exceed 10485760 bytes", 1<<(bits.UintSize-2)),
 	},
+	{
+		// int64 * int64 that overflows int64. See issue #2820: previously
+		// this silently wrapped to a wrong (negative) value.
+		description:   "Multiply integers that overflow int64",
+		skipDoc:       true,
+		document:      `a: 3000000000`,
+		expression:    `.a * 4000000000`,
+		expectedError: "3000000000 * 4000000000 overflows int64",
+	},
+	{
+		// MaxInt64 * 2 wraps to -2 without the overflow guard.
+		description:   "Multiply max int by 2 overflows int64",
+		skipDoc:       true,
+		document:      `a: 9223372036854775807`,
+		expression:    `.a * 2`,
+		expectedError: "9223372036854775807 * 2 overflows int64",
+	},
 }
 
 func TestMultiplyOperatorScenarios(t *testing.T) {

--- a/pkg/yqlib/operator_subtract.go
+++ b/pkg/yqlib/operator_subtract.go
@@ -104,7 +104,10 @@ func subtractScalars(context Context, target *CandidateNode, lhs *CandidateNode,
 		if err != nil {
 			return err
 		}
-		result := lhsNum - rhsNum
+		result, err := checkedInt64Arithmetic('-', lhsNum, rhsNum)
+		if err != nil {
+			return err
+		}
 		target.Tag = lhs.Tag
 		target.Value = fmt.Sprintf(format, result)
 	} else if (lhsTag == "!!int" || lhsTag == "!!float") && (rhsTag == "!!int" || rhsTag == "!!float") {

--- a/pkg/yqlib/operator_subtract_test.go
+++ b/pkg/yqlib/operator_subtract_test.go
@@ -157,6 +157,15 @@ var subtractOperatorScenarios = []expressionScenario{
 			"D0, P[], (!!seq)::[!goat {a: b}]\n",
 		},
 	},
+	{
+		// int64 - int64 that overflows int64. See issue #2820: previously
+		// this silently wrapped (MinInt64 - 1 -> MaxInt64).
+		description:   "Subtract integers that overflow int64",
+		skipDoc:       true,
+		document:      `a: -9223372036854775808`,
+		expression:    `.a - 1`,
+		expectedError: "-9223372036854775808 - 1 overflows int64",
+	},
 }
 
 func TestSubtractOperatorScenarios(t *testing.T) {


### PR DESCRIPTION
## Problem

Integer arithmetic (`+`, `-`, `*`) on two `!!int` values silently wraps on int64 overflow, producing wrong results:

```bash
$ yq -n '3000000000 * 4000000000'
-6446744073709551616          # expected: 1.2e19 (or an error)

$ yq -n '9223372036854775807 + 1'
-9223372036854775808          # wrapped to MinInt64
```

This is inconsistent with yq's own behaviour elsewhere: `parseInt64` already refuses out-of-range integer literals, and string repetition (`str * n`) guards against `len*n` overflow. Arithmetic should refuse out-of-range results too, rather than returning a wrapped (and therefore wrong) value.

Reported in #2820.

## Fix

Add `checkedInt64Arithmetic(op, lhs, rhs)`, which computes the exact result with `math/big` and returns an error when it falls outside `[MinInt64, MaxInt64]`. Using `big.Int` means the exact product/sum/difference is computed before the range check, avoiding the sign-handling pitfalls of detecting overflow directly on the wrapped `int64` result.

Wire it into the `!!int` branches of:
- `multiplyIntegers` (`*`)
- `addScalars` (`+`)
- `subtractScalars` (`-`)

## Behaviour after the fix

```bash
$ yq -n '3000000000 * 4000000000'
Error: 3000000000 * 4000000000 overflows int64

$ yq -n '9223372036854775807 + 1'
Error: 9223372036854775807 + 1 overflows int64

$ printf 'a: -9223372036854775808\n' | yq '.a - 1'
Error: -9223372036854775808 - 1 overflows int64
```

The error propagates through both the plain operators and the compound assign forms (`+=`, `-=`, `*=`).

## What's unchanged

- Non-overflowing arithmetic (e.g. `3 * 4`, `3 + 4`, `3 - 4`).
- Output formatting for ints (`%v` / `0x%X` / `0o%o`) — `0xF * 0x3` still yields `0x2D`.
- The mixed `!!int`/`!!float` paths (those go through `strconv.ParseFloat`).
- String repetition (already guarded separately).

## Tests

Added `skipDoc` scenarios to `operator_multiply_test.go`, `operator_add_test.go` and `operator_subtract_test.go` covering the overflow error for each operator (including the `MaxInt64 + 1` and `MinInt64 - 1` boundaries). Full `pkg/yqlib` suite passes:

```
ok  github.com/mikefarah/yq/v4/pkg/yqlib  0.495s
```

Fixes #2820.