### PR TITLE
fix(test): update expected format for unrecognised extension in format_test.go

### DIFF
--- a/test/format_test.go
+++ b/test/format_test.go
@@ -17,7 +17,7 @@ func TestFormatStringFromFilename(t *testing.T) {
 		{"FILE.JSON", "json"},
 		{"file.properties", "properties"},
 		{"file.xml", "xml"},
-		{"file.unknown", "unknown"},
+		{"file.unknown", "yaml"},
 
 		// filenames without extensions
 		{"file", "yaml"},


### PR DESCRIPTION
## Summary

Fixes #2822.

In `pkg/yqlib/format.go`, `FormatStringFromFilename` defaults unrecognised file extensions to `"yaml"` (and is tested as such in `pkg/yqlib/format_test.go` line 64: `FormatStringFromFilename("test.tfstate") == "yaml"`).

However, `test/format_test.go` still expected `"unknown"` for `"file.unknown"`, causing `go test ./test` to fail.

## Changes

- Updated the test expectation for `"file.unknown"` in `test/format_test.go` to `"yaml"`.

## Verification

- `go test ./test` passed cleanly.
- `go test ./pkg/yqlib` passed cleanly.
