### PR TITLE
fix: close split output files after writing

### DIFF
--- a/pkg/yqlib/printer.go
+++ b/pkg/yqlib/printer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"container/list"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -37,6 +38,23 @@ func NewPrinter(encoder Encoder, printerWriter PrinterWriter) Printer {
 		treeNavigator:     NewDataTreeNavigator(),
 		nulSepOutput:      false,
 	}
+}
+
+type printerWriterCloser interface {
+	CloseWriter() error
+}
+
+func usePrinterWriter(printerWriter PrinterWriter, node *CandidateNode, write func(*bufio.Writer) error) error {
+	writer, err := printerWriter.GetWriter(node)
+	if err != nil {
+		return err
+	}
+
+	writeErr := write(writer)
+	if closer, ok := printerWriter.(printerWriterCloser); ok {
+		return errors.Join(writeErr, closer.CloseWriter())
+	}
+	return writeErr
 }
 
 func (p *resultsPrinter) SetNulSepOutput(nulSepOutput bool) {
@@ -95,75 +113,69 @@ func (p *resultsPrinter) PrintResults(matchingNodes *list.List) error {
 	}
 
 	for el := matchingNodes.Front(); el != nil; el = el.Next() {
-
 		mappedDoc := el.Value.(*CandidateNode)
 		log.Debugf("print sep logic: p.firstTimePrinting: %v, previousDocIndex: %v", p.firstTimePrinting, p.previousDocIndex)
 		log.Debugf("%v", NodeToString(mappedDoc))
-		writer, errorWriting := p.printerWriter.GetWriter(mappedDoc)
-		if errorWriting != nil {
-			return errorWriting
-		}
 
-		commentsStartWithSepExp := regexp.MustCompile(`^\$yqDocSeparator\$`)
-		commentStartsWithSeparator := commentsStartWithSepExp.MatchString(mappedDoc.LeadingContent)
+		err := usePrinterWriter(p.printerWriter, mappedDoc, func(writer *bufio.Writer) error {
+			commentsStartWithSepExp := regexp.MustCompile(`^\$yqDocSeparator\$`)
+			commentStartsWithSeparator := commentsStartWithSepExp.MatchString(mappedDoc.LeadingContent)
 
-		if (p.previousDocIndex != mappedDoc.GetDocument() || p.previousFileIndex != mappedDoc.GetFileIndex()) && !commentStartsWithSeparator {
-			if err := p.encoder.PrintDocumentSeparator(writer); err != nil {
+			if (p.previousDocIndex != mappedDoc.GetDocument() || p.previousFileIndex != mappedDoc.GetFileIndex()) && !commentStartsWithSeparator {
+				if err := p.encoder.PrintDocumentSeparator(writer); err != nil {
+					return err
+				}
+			}
+
+			var destination io.Writer = writer
+			tempBuffer := bytes.NewBuffer(nil)
+			if p.nulSepOutput {
+				destination = tempBuffer
+			}
+
+			if err := p.encoder.PrintLeadingContent(destination, mappedDoc.LeadingContent); err != nil {
 				return err
 			}
-		}
 
-		var destination io.Writer = writer
-		tempBuffer := bytes.NewBuffer(nil)
-		if p.nulSepOutput {
-			destination = tempBuffer
-		}
-
-		if err := p.encoder.PrintLeadingContent(destination, mappedDoc.LeadingContent); err != nil {
-			return err
-		}
-
-		if err := p.printNode(mappedDoc, destination); err != nil {
-			return err
-		}
-
-		if p.nulSepOutput {
-			removeLastEOL(tempBuffer)
-			tempBufferBytes := tempBuffer.Bytes()
-			if bytes.IndexByte(tempBufferBytes, 0) != -1 {
-				return fmt.Errorf(
-					"can't serialise value because it contains NUL char and you are using NUL separated output",
-				)
-			}
-			if _, err := writer.Write(tempBufferBytes); err != nil {
+			if err := p.printNode(mappedDoc, destination); err != nil {
 				return err
 			}
-			if _, err := writer.Write([]byte{0}); err != nil {
-				return err
-			}
-		}
 
-		p.previousDocIndex = mappedDoc.GetDocument()
-		if err := writer.Flush(); err != nil {
+			if p.nulSepOutput {
+				removeLastEOL(tempBuffer)
+				tempBufferBytes := tempBuffer.Bytes()
+				if bytes.IndexByte(tempBufferBytes, 0) != -1 {
+					return fmt.Errorf(
+						"can't serialise value because it contains NUL char and you are using NUL separated output",
+					)
+				}
+				if _, err := writer.Write(tempBufferBytes); err != nil {
+					return err
+				}
+				if _, err := writer.Write([]byte{0}); err != nil {
+					return err
+				}
+			}
+
+			p.previousDocIndex = mappedDoc.GetDocument()
+			return writer.Flush()
+		})
+		if err != nil {
 			return err
 		}
-		log.Debugf("done printing results")
 	}
 
 	// what happens if I remove output format check?
 	if p.appendixReader != nil {
-		writer, err := p.printerWriter.GetWriter(nil)
+		err := usePrinterWriter(p.printerWriter, nil, func(writer *bufio.Writer) error {
+			log.Debug("Piping appendix reader...")
+			betterReader := bufio.NewReader(p.appendixReader)
+			if _, err := io.Copy(writer, betterReader); err != nil {
+				return err
+			}
+			return writer.Flush()
+		})
 		if err != nil {
-			return err
-		}
-
-		log.Debug("Piping appendix reader...")
-		betterReader := bufio.NewReader(p.appendixReader)
-		_, err = io.Copy(writer, betterReader)
-		if err != nil {
-			return err
-		}
-		if err := writer.Flush(); err != nil {
 			return err
 		}
 	}

--- a/pkg/yqlib/printer_node_info.go
+++ b/pkg/yqlib/printer_node_info.go
@@ -32,44 +32,36 @@ func (p *nodeInfoPrinter) PrintedAnything() bool {
 }
 
 func (p *nodeInfoPrinter) PrintResults(matchingNodes *list.List) error {
-
 	for el := matchingNodes.Front(); el != nil; el = el.Next() {
 		mappedDoc := el.Value.(*CandidateNode)
-		writer, errorWriting := p.printerWriter.GetWriter(mappedDoc)
-		if errorWriting != nil {
-			return errorWriting
-		}
-		bytes, err := yaml.Marshal(mappedDoc.ConvertToNodeInfo())
+		err := usePrinterWriter(p.printerWriter, mappedDoc, func(writer *bufio.Writer) error {
+			bytes, err := yaml.Marshal(mappedDoc.ConvertToNodeInfo())
+			if err != nil {
+				return err
+			}
+			if _, err := writer.Write(bytes); err != nil {
+				return err
+			}
+			if _, err := writer.Write([]byte("\n")); err != nil {
+				return err
+			}
+			p.printedMatches = true
+			return writer.Flush()
+		})
 		if err != nil {
-			return err
-		}
-		if _, err := writer.Write(bytes); err != nil {
-			return err
-		}
-		if _, err := writer.Write([]byte("\n")); err != nil {
-			return err
-		}
-		p.printedMatches = true
-		if err := writer.Flush(); err != nil {
 			return err
 		}
 	}
 
 	if p.appendixReader != nil {
-		writer, err := p.printerWriter.GetWriter(nil)
-		if err != nil {
-			return err
-		}
-
-		log.Debug("Piping appendix reader...")
-		betterReader := bufio.NewReader(p.appendixReader)
-		_, err = io.Copy(writer, betterReader)
-		if err != nil {
-			return err
-		}
-		if err := writer.Flush(); err != nil {
-			return err
-		}
+		return usePrinterWriter(p.printerWriter, nil, func(writer *bufio.Writer) error {
+			log.Debug("Piping appendix reader...")
+			betterReader := bufio.NewReader(p.appendixReader)
+			if _, err := io.Copy(writer, betterReader); err != nil {
+				return err
+			}
+			return writer.Flush()
+		})
 	}
 
 	return nil

--- a/pkg/yqlib/printer_writer.go
+++ b/pkg/yqlib/printer_writer.go
@@ -2,6 +2,7 @@ package yqlib
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,11 +28,16 @@ func (sp *singlePrinterWriter) GetWriter(_ *CandidateNode) (*bufio.Writer, error
 	return sp.bufferedWriter, nil
 }
 
+func (sp *singlePrinterWriter) CloseWriter() error {
+	return nil
+}
+
 type multiPrintWriter struct {
 	treeNavigator  DataTreeNavigator
 	nameExpression *ExpressionNode
 	extension      string
 	index          int
+	file           *os.File
 }
 
 func NewMultiPrinterWriter(expression *ExpressionNode, format *Format) PrinterWriter {
@@ -53,6 +59,13 @@ func NewMultiPrinterWriter(expression *ExpressionNode, format *Format) PrinterWr
 }
 
 func (sp *multiPrintWriter) GetWriter(node *CandidateNode) (*bufio.Writer, error) {
+	if node == nil {
+		return nil, errors.New("cannot append content to split output without a result")
+	}
+	if sp.file != nil {
+		return nil, fmt.Errorf("previous split output file is still open")
+	}
+
 	name := ""
 
 	indexVariableNode := CandidateNode{Kind: ScalarNode, Tag: "!!int", Value: fmt.Sprintf("%v", sp.index)}
@@ -75,13 +88,20 @@ func (sp *multiPrintWriter) GetWriter(node *CandidateNode) (*bufio.Writer, error
 	if err != nil {
 		return nil, err
 	}
-	f, err := os.Create(name)
-
+	sp.file, err = os.Create(name)
 	if err != nil {
 		return nil, err
 	}
-	sp.index = sp.index + 1
+	sp.index++
 
-	return bufio.NewWriter(f), nil
+	return bufio.NewWriter(sp.file), nil
+}
 
+func (sp *multiPrintWriter) CloseWriter() error {
+	if sp.file == nil {
+		return nil
+	}
+	err := sp.file.Close()
+	sp.file = nil
+	return err
 }

--- a/pkg/yqlib/printer_writer_test.go
+++ b/pkg/yqlib/printer_writer_test.go
@@ -1,0 +1,102 @@
+package yqlib
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"testing"
+)
+
+type failingPrinterEncoder struct{}
+
+func (failingPrinterEncoder) Encode(io.Writer, *CandidateNode) error {
+	return errors.New("encode failed")
+}
+
+func (failingPrinterEncoder) PrintDocumentSeparator(io.Writer) error {
+	return nil
+}
+
+func (failingPrinterEncoder) PrintLeadingContent(io.Writer, string) error {
+	return nil
+}
+
+func (failingPrinterEncoder) CanHandleAliases() bool {
+	return true
+}
+
+func TestMultiPrintWriterClosesSplitFiles(t *testing.T) {
+	InitExpressionParser()
+	t.Chdir(t.TempDir())
+
+	expression, err := ExpressionParser.ParseExpression(`$index | tostring`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	printer := NewPrinter(
+		NewYamlEncoder(NewDefaultYamlPreferences()),
+		NewMultiPrinterWriter(expression, YamlFormat),
+	)
+
+	matches := list.New()
+	for i := range 40 {
+		matches.PushBack(&CandidateNode{
+			Kind:  ScalarNode,
+			Tag:   "!!str",
+			Value: fmt.Sprintf("item-%d", i),
+		})
+	}
+
+	oldGCPercent := debug.SetGCPercent(-1)
+	t.Cleanup(func() { debug.SetGCPercent(oldGCPercent) })
+	before := countOpenFileDescriptors()
+	if err := printer.PrintResults(matches); err != nil {
+		t.Fatal(err)
+	}
+	after := countOpenFileDescriptors()
+	if after > before {
+		t.Fatalf("open file descriptors grew from %d to %d", before, after)
+	}
+
+	for i := range 40 {
+		filename := filepath.Join(".", fmt.Sprintf("%d.yml", i))
+		content, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(content) != fmt.Sprintf("item-%d\n", i) {
+			t.Fatalf("%s contains %q", filename, content)
+		}
+	}
+}
+
+func TestMultiPrintWriterClosesSplitFilesOnEncodeError(t *testing.T) {
+	InitExpressionParser()
+	t.Chdir(t.TempDir())
+
+	expression, err := ExpressionParser.ParseExpression(`$index | tostring`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	printer := NewPrinter(
+		failingPrinterEncoder{},
+		NewMultiPrinterWriter(expression, YamlFormat),
+	)
+	matches := list.New()
+	matches.PushBack(&CandidateNode{Kind: ScalarNode, Tag: "!!str", Value: "item"})
+
+	oldGCPercent := debug.SetGCPercent(-1)
+	t.Cleanup(func() { debug.SetGCPercent(oldGCPercent) })
+	before := countOpenFileDescriptors()
+	if err := printer.PrintResults(matches); err == nil {
+		t.Fatal("expected encoding error")
+	}
+	after := countOpenFileDescriptors()
+	if after > before {
+		t.Fatalf("open file descriptors grew from %d to %d", before, after)
+	}
+}


### PR DESCRIPTION
> Generated by an AI agent acting on the user's behalf, not the user personally.

## Summary

- Close every split output file after its buffered writer is flushed.
- Preserve the public `PrinterWriter` interface through an internal optional close capability.
- Close files on encoding and flush errors as well as successful writes.
- Return an explicit error when appendix output has no result-derived split filename.

## Problem

`multiPrintWriter.GetWriter` opens each output with `os.Create` and returns only a `bufio.Writer`. The underlying `*os.File` owner is lost, so repeated split output retains one file descriptor per result until process cleanup.

## Compatibility

Normal and split output bytes are unchanged. Existing external `PrinterWriter` implementations do not need a new method because closing is an internal optional capability.

## Verification

- `go test ./pkg/yqlib -run '^TestMultiPrintWriterClosesSplitFiles' -count=1`
- `go test ./pkg/yqlib -count=1`
- `./scripts/check.sh lint`

The regression tests disable garbage collection and verify stable descriptor counts after successful output and an encoder error. They also verify every generated file's bytes.

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.