### PR TITLE
fix: close files opened by format-aware load operators

### DIFF
--- a/pkg/yqlib/operator_load.go
+++ b/pkg/yqlib/operator_load.go
@@ -39,6 +39,7 @@ func loadWithDecoder(filename string, decoder Decoder) (*CandidateNode, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer safelyCloseFile(file)
 	reader := bufio.NewReader(file)
 
 	documents, err := readDocuments(reader, filename, 0, decoder)

--- a/pkg/yqlib/operator_load_test.go
+++ b/pkg/yqlib/operator_load_test.go
@@ -1,6 +1,12 @@
 package yqlib
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/debug"
 	"testing"
 )
 
@@ -179,4 +185,69 @@ func TestLoadOperatorSecurityDisabledScenarios(t *testing.T) {
 		testScenario(t, &tt)
 	}
 	appendOperatorDocumentScenario(t, "load", loadOperatorSecurityDisabledScenarios)
+}
+
+func TestLoadWithDecoderClosesFiles(t *testing.T) {
+	InitExpressionParser()
+
+	filenames := make([]string, 40)
+	dir := t.TempDir()
+	for i := range filenames {
+		filename := filepath.Join(dir, fmt.Sprintf("input-%d.yml", i))
+		if err := os.WriteFile(filename, []byte("value: test\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		filenames[i] = filename
+	}
+
+	previousGCPercent := debug.SetGCPercent(-1)
+	t.Cleanup(func() { debug.SetGCPercent(previousGCPercent) })
+	before := countOpenFileDescriptors()
+	for _, filename := range filenames {
+		node, err := loadWithDecoder(filename, NewYamlDecoder(ConfiguredYamlPreferences))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if node.Kind != MappingNode {
+			t.Fatalf("got node kind %v, want mapping", node.Kind)
+		}
+	}
+	after := countOpenFileDescriptors()
+	if after > before {
+		t.Fatalf("open file descriptors grew from %d to %d", before, after)
+	}
+}
+
+type failingLoadDecoder struct {
+	err error
+}
+
+func (decoder failingLoadDecoder) Init(io.Reader) error {
+	return nil
+}
+
+func (decoder failingLoadDecoder) Decode() (*CandidateNode, error) {
+	return nil, decoder.err
+}
+
+func TestLoadWithDecoderClosesFilesOnDecodeError(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "input.yml")
+	if err := os.WriteFile(filename, []byte("value: test\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	previousGCPercent := debug.SetGCPercent(-1)
+	t.Cleanup(func() { debug.SetGCPercent(previousGCPercent) })
+	decodeErr := errors.New("decode failed")
+	before := countOpenFileDescriptors()
+	for range 40 {
+		_, err := loadWithDecoder(filename, failingLoadDecoder{err: decodeErr})
+		if !errors.Is(err, decodeErr) {
+			t.Fatalf("loadWithDecoder() error = %v, want %v", err, decodeErr)
+		}
+	}
+	after := countOpenFileDescriptors()
+	if after > before {
+		t.Fatalf("open file descriptors grew from %d to %d", before, after)
+	}
 }


### PR DESCRIPTION
> Generated by an AI agent acting on the user's behalf, not the user personally.

## Summary

- Close files opened by `loadWithDecoder` after every load operation.
- Cover successful decoding and decoder failures with file-descriptor regressions.
- Preserve the existing decoder API and load semantics.

## Problem

`loadWithDecoder` opens the requested file and wraps it in `bufio.Reader`, but no owner closes the underlying `*os.File`. Repeated `load`, `load_yaml`, `load_json`, and other format-aware load calls can therefore retain one descriptor per call until process cleanup. `load_str` uses `os.ReadFile` and is not affected.

## Implementation

The file is closed with the existing `safelyCloseFile` helper through a defer registered immediately after `os.Open` succeeds. This covers decoder initialisation, document decoding, and successful returns.

## Verification

- `go test ./pkg/yqlib -run '^TestLoadWithDecoderClosesFiles' -count=1`
- `go test ./pkg/yqlib -count=1`
- `./scripts/check.sh lint`

The regression tests disable garbage collection and verify stable descriptor counts across 40 successful loads and 40 deterministic decoder failures. The decoder error remains identifiable through `errors.Is`.

I searched open and closed upstream issues and pull requests by the affected symbol, load operators, and file-descriptor symptom and found no matching report or fix.

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.