### PR TITLE
docs: fix dead snapcraft confinement link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ snap install yq
 ```
 
 #### Snap notes
-`yq` installs with [_strict confinement_](https://docs.snapcraft.io/snap-confinement/6233) in snap, this means it doesn't have direct access to root files. To read root files you can:
+`yq` installs with [_strict confinement_](https://snapcraft.io/docs/snap-confinement) in snap, this means it doesn't have direct access to root files. To read root files you can:
 
 ```
 sudo cat /etc/myfile | yq '.a.path'


### PR DESCRIPTION
## Description
Fixes a dead external link in README.md. The strict-confinement note pointed at
`https://docs.snapcraft.io/snap-confinement/6233`, which now returns **404**
(the Snapcraft docs were restructured under `snapcraft.io/docs`). This PR points
it at the current `https://snapcraft.io/docs/snap-confinement` page, which
returns **HTTP 200** (verified after following redirects).

## Scope
- `README.md` L118: replaced the dead `docs.snapcraft.io/snap-confinement/6233`
  URL with the live `snapcraft.io/docs/snap-confinement` URL.
- Docs-only change. No behavior, build, or test impact.

## Verification
- Old URL: `curl -sIL https://docs.snapcraft.io/snap-confinement/6233` → 404.
- New URL: `curl -sIL https://snapcraft.io/docs/snap-confinement` → 200.
- Full external-link sweep of the repo surfaced only this one genuinely dead
  user-facing doc link (other apparent 4xx/403 hits were bot-blocked hosts such
  as linux.die.net / StackOverflow, which return 200 to real browsers).

## AI assistance disclosure
This contribution was prepared with the help of an AI assistant for link-target
research and verification; the final change and the decision to submit were made
by the human author.

## Checklist
- [x] I have read the contributing guidelines
- [x] The change is documentation-only