### PR TITLE
fix(windows): yq -i drops file ACLs on Windows

### DIFF
--- a/pkg/yqlib/file_utils.go
+++ b/pkg/yqlib/file_utils.go
@@ -15,7 +15,7 @@ func tryRenameFile(from string, to string) error {
 		}
 		tryRemoveTempFile(from)
 		return nil
-	} else if renameError := os.Rename(from, to); renameError != nil {
+	} else if renameError := renameFile(from, to); renameError != nil {
 		log.Debugf("Error renaming from %v to %v, attempting to copy contents", from, to)
 		log.Debug(renameError.Error())
 		log.Debug("going to try copying instead")

--- a/pkg/yqlib/rename_not_windows.go
+++ b/pkg/yqlib/rename_not_windows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package yqlib
+
+import "os"
+
+func renameFile(from string, to string) error {
+	return os.Rename(from, to)
+}

--- a/pkg/yqlib/rename_windows.go
+++ b/pkg/yqlib/rename_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package yqlib
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	modkernel32      = windows.NewLazySystemDLL("kernel32.dll")
+	procReplaceFileW = modkernel32.NewProc("ReplaceFileW")
+)
+
+// renameFile moves 'from' onto 'to'. When 'to' already exists, the Win32 ReplaceFile
+// API is used instead of a plain os.Rename (which uses MoveFileEx under the hood):
+// ReplaceFile preserves the replaced file's ACLs, alternate data streams and other
+// NTFS-specific attributes, which is what an atomic in-place edit is expected to do.
+// Without this, yq -i silently drops any ACEs on the original file that grant access
+// to users other than the one running yq, since the temp file created for the edit
+// only inherits the ACL of its own (unrelated) parent directory.
+//
+// golang.org/x/sys/windows does not wrap ReplaceFile, so it is called directly.
+func renameFile(from string, to string) error {
+	if _, err := os.Lstat(to); err != nil {
+		// Target doesn't exist yet (or isn't statable) - nothing to preserve, a plain
+		// rename is sufficient and ReplaceFile requires the target to already exist.
+		return os.Rename(from, to)
+	}
+
+	replacedName, err := windows.UTF16PtrFromString(to)
+	if err != nil {
+		return err
+	}
+	replacementName, err := windows.UTF16PtrFromString(from)
+	if err != nil {
+		return err
+	}
+
+	ret, _, callErr := procReplaceFileW.Call(
+		uintptr(unsafe.Pointer(replacedName)),
+		uintptr(unsafe.Pointer(replacementName)),
+		0, // lpBackupFileName - no backup kept
+		0, // dwReplaceFlags
+		0, // lpExclude - reserved, must be NULL
+		0, // lpReserved - reserved, must be NULL
+	)
+	if ret == 0 {
+		return callErr
+	}
+	return nil
+}

--- a/pkg/yqlib/rename_windows_test.go
+++ b/pkg/yqlib/rename_windows_test.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package yqlib
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression test for the ACL-loss bug: replacing an existing file via renameFile
+// must preserve explicit (non-inherited) ACEs on the replaced file, the way an
+// atomic in-place edit is expected to. Before the fix, this went through os.Rename
+// (MoveFileEx), which does not guarantee that.
+func TestRenameFilePreservesACL(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.yaml")
+	replacement := filepath.Join(dir, "replacement.yaml")
+
+	if err := os.WriteFile(target, []byte("a: 1\n"), 0644); err != nil {
+		t.Fatalf("failed to create target file: %v", err)
+	}
+	if err := os.WriteFile(replacement, []byte("a: 2\n"), 0644); err != nil {
+		t.Fatalf("failed to create replacement file: %v", err)
+	}
+
+	// Grant an explicit (non-inherited) ACE that would not otherwise exist on a
+	// fresh temp file, so its survival is a meaningful signal.
+	if out, err := exec.Command("icacls", target, "/grant", "Users:(F)").CombinedOutput(); err != nil {
+		t.Fatalf("icacls grant failed: %v\n%s", err, out)
+	}
+
+	before, err := exec.Command("icacls", target).CombinedOutput()
+	if err != nil {
+		t.Fatalf("icacls (before) failed: %v\n%s", err, before)
+	}
+	if !strings.Contains(string(before), `BUILTIN\Users:(F)`) {
+		t.Fatalf("test setup did not actually grant the expected ACE, got:\n%s", before)
+	}
+
+	if err := renameFile(replacement, target); err != nil {
+		t.Fatalf("renameFile failed: %v", err)
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read target after renameFile: %v", err)
+	}
+	if string(content) != "a: 2\n" {
+		t.Fatalf("target file content wrong after renameFile: got %q", content)
+	}
+
+	after, err := exec.Command("icacls", target).CombinedOutput()
+	if err != nil {
+		t.Fatalf("icacls (after) failed: %v\n%s", err, after)
+	}
+	if !strings.Contains(string(after), `BUILTIN\Users:(F)`) {
+		t.Fatalf("renameFile did not preserve the explicit ACE on the replaced file.\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}


### PR DESCRIPTION
## Problem

`yq -i '.setting = "value"' config.yml` on Windows, run as a non-admin user, silently strips file permissions for that user, sometimes leaving `Access denied` on subsequent access.

## Root cause

`WriteInPlaceHandler` writes the evaluated result to a fresh temp file, then calls `tryRenameFile` to move it over the original (`write_in_place_handler.go`, `file_utils.go`). That final step used plain `os.Rename`, which on Windows compiles down to `MoveFileEx`. `MoveFileEx` does not guarantee the replaced file's ACL is preserved — in practice the temp file's own ACL (inherited from `%TEMP%`, an unrelated directory) ends up replacing the original file's ACL, silently dropping any ACEs that granted access to users other than the one running yq.

The existing code already special-cases mode bits (`os.Chmod`) and ownership (`changeOwner`) when creating the temp file, but neither of those covers Windows' ACL-based security model.

## Fix

Added a platform-specific `renameFile` (mirroring the existing `chown_linux.go` / `chown_not_linux_os.go` split in this package):
- Non-Windows: unchanged, plain `os.Rename`.
- Windows: uses the Win32 `ReplaceFile` API (not `MoveFileEx`) when the target already exists, which is specifically designed to preserve the replaced file's ACL, alternate data streams, and other NTFS attributes — falls back to `os.Rename` only when the target doesn't exist yet (`ReplaceFile` requires an existing target). `golang.org/x/sys/windows` doesn't wrap `ReplaceFile`, so it's called directly via `NewLazySystemDLL`.

## Testing

This is a genuine before/after fix I verified for real on Windows, not just reasoned through:

1. Built both the original (unpatched) and patched binaries.
2. Created a test file, granted an explicit `BUILTIN\Users:(F)` ACE via `icacls` (not something a fresh temp file would have).
3. Ran the **original** binary's `-i`: the explicit ACE and all inherited ACEs were wiped, replaced with just the temp file's default ACL (SYSTEM/Administrators/current user) — reproducing this issue exactly.
4. Reset and ran the **patched** binary's `-i`: `BUILTIN\Users:(F)` survived, and the file content updated correctly.
5. Added `TestRenameFilePreservesACL` (Windows-only), which does the same check programmatically via `icacls`. Verified it fails against the old `os.Rename`-only behavior and passes with the fix.
6. Ran the full `pkg/yqlib` suite locally on Windows: no new failures. Two pre-existing failures I confirmed also happen identically on unmodified `master` in this environment, unrelated to this change: `TestSystemOperatorEnabledScenarios` (Git-Bash-on-Windows path mangling when shelling out) and `TestWriteInPlaceHandlerImpl_FinishWriteInPlace_Symlink_Success` (symlink creation needs elevated privilege/Developer Mode, which this environment doesn't have).

Fixes #2845