### PR TITLE
fix: preserve YAML structure when assigning head comments

### DIFF
--- a/acceptance_tests/leading-separator.sh
+++ b/acceptance_tests/leading-separator.sh
@@ -417,8 +417,8 @@ a: test
 b: sane
 EOL
 
-  # it will be hard to remove that top level separator
   read -r -d '' expected << EOM
+---
 a: test
 ---
 b: sane

--- a/pkg/yqlib/operator_comments.go
+++ b/pkg/yqlib/operator_comments.go
@@ -5,12 +5,23 @@ import (
 	"bytes"
 	"container/list"
 	"regexp"
+	"strings"
 )
 
 type commentOpPreferences struct {
 	LineComment bool
 	HeadComment bool
 	FootComment bool
+}
+
+func structuralLeadingContent(content string) string {
+	var preserved strings.Builder
+	for _, line := range strings.SplitAfter(content, "\n") {
+		if strings.TrimSpace(line) == "$yqDocSeparator$" || yamlDirectiveLineRe.MatchString(line) {
+			preserved.WriteString(line)
+		}
+	}
+	return preserved.String()
 }
 
 func assignCommentsOperator(d *dataTreeNavigator, context Context, expressionNode *ExpressionNode) (Context, error) {
@@ -62,7 +73,7 @@ func assignCommentsOperator(d *dataTreeNavigator, context Context, expressionNod
 		}
 		if preferences.HeadComment {
 			candidate.HeadComment = comment
-			candidate.LeadingContent = "" // clobber the leading content, if there was any.
+			candidate.LeadingContent = structuralLeadingContent(candidate.LeadingContent)
 		}
 		if preferences.FootComment {
 			candidate.FootComment = comment

--- a/pkg/yqlib/operator_comments_test.go
+++ b/pkg/yqlib/operator_comments_test.go
@@ -150,6 +150,52 @@ var commentOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
+		skipDoc:     true,
+		description: "Set head comment after an explicit document separator",
+		document:    "---\na: cat",
+		expression:  `. head_comment="new"`,
+		expected: []string{
+			"D0, P[], (!!map)::---\n# new\na: cat\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "Set head comments in a multi-document stream",
+		document:    "---\n# old first\na: cat\n---\na: dog",
+		expression:  `. head_comment="new"`,
+		expected: []string{
+			"D0, P[], (!!map)::---\n# new\na: cat\n",
+			"D1, P[], (!!map)::# new\na: dog\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "Set head comment after a YAML directive",
+		document:    "%YAML 1.1\n---\n# old\na: cat",
+		expression:  `. head_comment="new"`,
+		expected: []string{
+			"D0, P[], (!!map)::%YAML 1.1\n---\n# new\na: cat\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "Replace an ordinary leading comment",
+		document:    "# old\na: cat",
+		expression:  `. head_comment="new"`,
+		expected: []string{
+			"D0, P[], (!!map)::# new\na: cat\n",
+		},
+	},
+	{
+		skipDoc:     true,
+		description: "Remove head comment without removing YAML structure",
+		document:    "%YAML 1.1\n---\n# old\na: cat",
+		expression:  `. head_comment=""`,
+		expected: []string{
+			"D0, P[], (!!map)::%YAML 1.1\n---\na: cat\n",
+		},
+	},
+	{
 		description: "Set head comment of a map entry",
 		document:    "f: foo\na:\n  b: cat",
 		expression:  `(.a | key) head_comment="single"`,


### PR DESCRIPTION
## Summary

Assigning a head comment to the root of a YAML document currently removes an explicit first `---`. The decoder stores that separator, along with supported `%YAML` directives and ordinary header comments, in `LeadingContent`; head-comment assignment clears the field wholesale.

Preserve separator sentinels and YAML directive lines while replacing the comment portion of leading content. Ordinary head comments are still replaced or removed, and the change stays within the comment operator rather than altering printer behaviour. Removing comments now also leaves structural YAML content intact.

Fixes #1836.

## Tests

- Added comment-operator scenarios for first-document separators, multi-document streams, YAML directives, replacement, and removal
- Updated the leading-separator acceptance expectation for comment removal
- `make test`
- `bash scripts/acceptance.sh`
