### PR TITLE
fix: preserve explicit assignments in read-only expressions

### DIFF
--- a/pkg/yqlib/operator_assign.go
+++ b/pkg/yqlib/operator_assign.go
@@ -30,7 +30,7 @@ func getAssignPreferences(preferences interface{}) assignPreferences {
 }
 
 func assignUpdateOperator(d *dataTreeNavigator, context Context, expressionNode *ExpressionNode) (Context, error) {
-	lhs, err := d.GetMatchingNodes(context, expressionNode.LHS)
+	lhs, err := d.GetMatchingNodes(context.WritableClone(), expressionNode.LHS)
 	if err != nil {
 		return Context{}, err
 	}

--- a/pkg/yqlib/operator_multiply_test.go
+++ b/pkg/yqlib/operator_multiply_test.go
@@ -440,6 +440,15 @@ var multiplyOperatorScenarios = []expressionScenario{
 		},
 	},
 	{
+		description: "Merge only existing fields into a constructed object",
+		skipDoc:     true,
+		document:    `{a: {b: 1, c: 2}}`,
+		expression:  `({} | .a.b = 3) *? .`,
+		expected: []string{
+			"D0, P[], (!!map)::{a: {b: 1}}\n",
+		},
+	},
+	{
 		description: "Merge, only new fields",
 		document:    `{a: {thing: one, cat: frog}, b: {missing: two, thing: two}}`,
 		expression:  `.a *n .b`,


### PR DESCRIPTION
> AI agent disclosure: This pull request was prepared and submitted by Codex acting on RRXXZZYY's behalf, not by the account owner personally.

## Summary

Fixes #2848.

Binary operators evaluate their operands with automatic path creation disabled. That read-only setting also reached an explicit assignment inside an operand, so `({} | .a.b = 3)` stayed empty when used on the left side of `*?`.

Evaluate assignment targets with a writable context clone. Ordinary operand traversal remains read-only, while an explicit assignment can create its target as it does outside a binary expression.

## Test Plan

- `go test ./pkg/yqlib -run '^(TestMultiplyOperatorScenarios|TestAssignOperatorScenarios|TestPipeOperatorScenarios)$' -count=1`
- `go test . ./cmd ./test -count=1`
- `go test ./pkg/yqlib -skip '^(TestLoadScenarios|TestSystemOperatorEnabledScenarios|TestWriteInPlaceHandlerImpl_FinishWriteInPlace_Symlink_Success)$' -count=1`
- `scripts/format.sh`
- `scripts/spelling.sh`
- `scripts/check.sh` (0 issues)
- Built the CLI and verified the issue reproducer now returns only `a.b: 1`; the existing read-only regression still leaves `x: null`.

The unfiltered suite was also attempted on Windows. The three skipped tests fail unchanged on the upstream commit because of CRLF expectations, a Git Bash executable path containing spaces, and unavailable symlink privileges.