### PR TITLE
Fix color output issue with /dev/null redirection

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mattn/go-isatty"
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
 	"github.com/spf13/cobra"
 )
@@ -45,9 +46,10 @@ func initCommand(cmd *cobra.Command, args []string) (string, []string, error) {
 }
 
 func setupColors() {
-	fileInfo, _ := os.Stdout.Stat()
-
-	if forceColor || (!forceNoColor && (fileInfo.Mode()&os.ModeCharDevice) != 0) {
+	fd := os.Stdout.Fd()
+	// os.Stdout can be a regular file, pipe, or other character device such
+	// as /dev/null - only a real terminal should get colourised output.
+	if forceColor || (!forceNoColor && (isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd))) {
 		colorsEnabled = true
 	}
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
@@ -959,6 +962,103 @@ func TestSetupColors(t *testing.T) {
 
 			if colorsEnabled != tt.expectColors {
 				t.Errorf("setupColors() colorsEnabled = %v, want %v", colorsEnabled, tt.expectColors)
+			}
+		})
+	}
+}
+
+// terminalCase is a file/device to test setupColors against, paired with
+// whether it should be treated as an interactive terminal - so what does
+// and doesn't get colourised output is visible in a single place.
+type terminalCase struct {
+	open   func(t *testing.T) *os.File
+	isTerm bool
+}
+
+func terminalTestCases() map[string]terminalCase {
+	return map[string]terminalCase{
+		"regular file": {isTerm: false, open: func(t *testing.T) *os.File {
+			f, err := os.CreateTemp(t.TempDir(), "isterminal")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+			return f
+		}},
+		"/dev/null": {isTerm: false, open: func(t *testing.T) *os.File {
+			f, err := os.OpenFile(os.DevNull, os.O_RDWR, 0644)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", os.DevNull, err)
+			}
+			return f
+		}},
+		"unnamed pipe, read end": {isTerm: false, open: func(t *testing.T) *os.File {
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("failed to create pipe: %v", err)
+			}
+			w.Close()
+			return r
+		}},
+		"unnamed pipe, write end (e.g. piped to a pager)": {isTerm: false, open: func(t *testing.T) *os.File {
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("failed to create pipe: %v", err)
+			}
+			r.Close()
+			return w
+		}},
+		"named pipe (FIFO)": {isTerm: false, open: func(t *testing.T) *os.File {
+			if runtime.GOOS == "windows" {
+				t.Skip("named pipes not supported by this test on windows")
+			}
+			path := filepath.Join(t.TempDir(), "fifo")
+			if err := syscall.Mkfifo(path, 0600); err != nil {
+				t.Fatalf("failed to create named pipe: %v", err)
+			}
+			// O_RDWR avoids blocking on open: a FIFO opened only for reading
+			// (or only writing) blocks until a peer opens the other end.
+			f, err := os.OpenFile(path, os.O_RDWR, os.ModeNamedPipe)
+			if err != nil {
+				t.Fatalf("failed to open named pipe: %v", err)
+			}
+			return f
+		}},
+		"controlling terminal (/dev/tty)": {isTerm: true, open: func(t *testing.T) *os.File {
+			f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+			if err != nil {
+				t.Skipf("no controlling terminal available in this environment: %v", err)
+			}
+			return f
+		}},
+	}
+}
+
+func TestSetupColorsForFileKind(t *testing.T) {
+	for name, tc := range terminalTestCases() {
+		t.Run(name, func(t *testing.T) {
+			f := tc.open(t)
+			defer f.Close()
+
+			originalStdout := os.Stdout
+			originalForceColor := forceColor
+			originalForceNoColor := forceNoColor
+			originalColorsEnabled := colorsEnabled
+			defer func() {
+				os.Stdout = originalStdout
+				forceColor = originalForceColor
+				forceNoColor = originalForceNoColor
+				colorsEnabled = originalColorsEnabled
+			}()
+
+			os.Stdout = f
+			forceColor = false
+			forceNoColor = false
+			colorsEnabled = false
+
+			setupColors()
+
+			if colorsEnabled != tc.isTerm {
+				t.Errorf("setupColors() colorsEnabled = %v, want %v for %s", colorsEnabled, tc.isTerm, name)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/jinzhu/copier v0.4.0
 	github.com/magiconair/properties v1.18.11
+	github.com/mattn/go-isatty v0.0.20
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e
 	github.com/spf13/cobra v1.10.2
@@ -32,7 +33,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect


### PR DESCRIPTION
`os.ModeCharDevice` matches `/dev/null` too, so redirecting there silently turned on colorized (and much slower) output. Using `isatty instead, like fatih/color already does internally - no new dependency needed.

Tests cover a regular file, `/dev/null`, pipes and a real tty.
Fixes #1918 