### PR TITLE
Resolve aliases when flattening sequences (#2851)

### DIFF
--- a/pkg/yqlib/doc/operators/flatten.md
+++ b/pkg/yqlib/doc/operators/flatten.md
@@ -69,3 +69,26 @@ will output
 - foo: baz
 ```
 
+## Flatten aliased array
+Aliases are resolved before flattening.
+
+Given a sample.yml file of:
+```yaml
+base: &base
+  - item1
+  - item2
+list:
+  - *base
+  - item3
+```
+then
+```bash
+yq '.list | flatten' sample.yml
+```
+will output
+```yaml
+- item1
+- item2
+- item3
+```
+

--- a/pkg/yqlib/operator_flatten.go
+++ b/pkg/yqlib/operator_flatten.go
@@ -19,10 +19,14 @@ func flatten(node *CandidateNode, depth int) {
 	newSeq := make([]*CandidateNode, 0)
 
 	for i := 0; i < len(content); i++ {
-		if content[i].Kind == SequenceNode {
-			flatten(content[i], depth-1)
-			for j := 0; j < len(content[i].Content); j++ {
-				newSeq = append(newSeq, content[i].Content[j])
+		child := content[i]
+		if child.Kind == AliasNode && child.Alias != nil {
+			child = child.Alias.Copy()
+		}
+		if child.Kind == SequenceNode {
+			flatten(child, depth-1)
+			for j := 0; j < len(child.Content); j++ {
+				newSeq = append(newSeq, child.Content[j])
 			}
 		} else {
 			newSeq = append(newSeq, content[i])

--- a/pkg/yqlib/operator_flatten_test.go
+++ b/pkg/yqlib/operator_flatten_test.go
@@ -60,6 +60,15 @@ var flattenOperatorScenarios = []expressionScenario{
 			"D0, P[], (!!seq)::[{foo: bar}, {foo: baz}]\n",
 		},
 	},
+	{
+		description:    "Flatten aliased array",
+		subdescription: "Aliases are resolved before flattening.",
+		document:       "base: &base [item1, item2]\nlist: [*base, item3]\n",
+		expression:     `.list | flatten`,
+		expected: []string{
+			"D0, P[list], (!!seq)::[item1, item2, item3]\n",
+		},
+	},
 }
 
 func TestFlattenOperatorScenarios(t *testing.T) {


### PR DESCRIPTION
> Generated by an AI agent (Claude) acting on Vladimir Babin's behalf, not the user personally.

Fixes #2851

## What

`flatten` didn't resolve YAML aliases. When a sequence element is an alias to another list (`- *base`), it was left as-is instead of being expanded, so `.list | flatten` returned the alias node unchanged.

## Fix

In `flatten`, dereference an `AliasNode` to a copy of its target before deciding whether to descend into it. Using a copy keeps the anchor target itself unmutated (the `&base` list in the source document stays intact).

## Tests

Added a scenario to `operator_flatten_test.go` (also generates a doc example):

```yaml
base: &base [item1, item2]
list: [*base, item3]
```
`.list | flatten` → `[item1, item2, item3]`.

## Validation

```
$ go test ./pkg/yqlib/ -run TestFlattenOperatorScenarios
ok  github.com/mikefarah/yq/v4/pkg/yqlib

# RED->GREEN: revert only operator_flatten.go, keep the new test
$ git stash push pkg/yqlib/operator_flatten.go && go test ./pkg/yqlib/ -run TestFlattenOperatorScenarios
--- FAIL  got [*base, item3], want [item1, item2, item3]
$ git stash pop && go test ./pkg/yqlib/
ok  github.com/mikefarah/yq/v4/pkg/yqlib
```

Manual check the anchor target is not mutated:
```
$ printf 'base_list: &base\n  - item1\n  - item2\n\nextended_list:\n  - *base\n  - item3\n' | ./yq '.extended_list |= flatten'
base_list: &base
  - item1
  - item2
extended_list:
  - item1
  - item2
  - item3
```

Full `pkg/yqlib` suite passes, `gofmt`/`go vet` clean. Happy to adjust.
