### PR TITLE
Fix spurious leading comment blank line with CRLF

### DIFF
--- a/pkg/yqlib/encoder.go
+++ b/pkg/yqlib/encoder.go
@@ -66,7 +66,7 @@ func PrintYAMLLeadingContent(writer io.Writer, content string, PrintDocSeparator
 			}
 
 		} else {
-			if len(readline) > 0 && readline != "\n" && readline[0] != '%' && !commentLineRe.MatchString(readline) {
+			if len(readline) > 0 && strings.TrimRight(readline, "\r\n") != "" && readline[0] != '%' && !commentLineRe.MatchString(readline) {
 				readline = "# " + readline
 			}
 			if ColorsEnabled && strings.TrimSpace(readline) != "" {

--- a/pkg/yqlib/yaml_test.go
+++ b/pkg/yqlib/yaml_test.go
@@ -32,6 +32,12 @@ var yamlFormatScenarios = []formatScenario{
 		expected:    "%YAML 1.1\r\n---\r\ncat\r\n",
 	},
 	{
+		description: "leading comment blank line (CRLF)",
+		skipDoc:     true,
+		input:       "# comment\r\n\r\ncat\r\n",
+		expected:    "# comment\r\n\r\ncat\r\n",
+	},
+	{
 		description: "comment only no trailing newline",
 		skipDoc:     true,
 		input:       "# hello",


### PR DESCRIPTION
Generated by Cursor acting on the user's behalf, not the user personally.

Fixes a leading-comment round-trip bug where a blank line inside a document's leading `#`-comment block was rewritten as a comment when the file used CRLF line endings (`# \r\n`).

**Root cause:** `PrintYAMLLeadingContent` in `pkg/yqlib/encoder.go` only treated a line as blank when it was exactly `"\n"`. A CRLF blank line (`"\r\n"`) failed that check and was prefixed with `# `.

**Fix:** Treat a line as blank when `strings.TrimRight(readline, "\r\n") == ""`, so both LF and CRLF blank lines are left untouched.

**Tests:** Added a `yamlFormatScenarios` case in `pkg/yqlib/yaml_test.go` with a leading comment block that contains a CRLF blank line, expecting the round-trip output to match the input. `TestYamlFormatScenarios`, full `pkg/yqlib` unit tests, `scripts/test.sh`, spelling, golangci-lint, and gosec all pass.

Scoped to the leading-comment-block path only (issue #2578). Does not change multi-document comment migration (issue #1871).

Fixes #2578